### PR TITLE
Fix trust relationship for ParameterStoreReadOnly-VNC role

### DIFF
--- a/vnc_assume_role_policy_doc.tf
+++ b/vnc_assume_role_policy_doc.tf
@@ -1,6 +1,6 @@
 # ------------------------------------------------------------------------------
-# Create an IAM policy document that allows EC2 instances
-# to assume the role this policy is attached to.
+# Create an IAM policy document that only allows specific instance profile
+# roles to assume the role this policy is attached to.
 # ------------------------------------------------------------------------------
 
 data "aws_iam_policy_document" "vnc_assume_role_doc" {
@@ -10,9 +10,9 @@ data "aws_iam_policy_document" "vnc_assume_role_doc" {
     ]
 
     principals {
-      type = "Service"
+      type = "AWS"
       identifiers = [
-        "ec2.amazonaws.com",
+        aws_iam_role.guacamole_instance_role.arn
       ]
     }
   }


### PR DESCRIPTION

# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR correctly sets the Guacamole instance profile role to be the only trusted entity (so far) that is allowed to assume the ParameterStoreReadOnly-VNC role.

<!--- Describe your changes in detail -->

## 💭 Motivation and Context
As mentioned [here](https://github.com/cisagov/cool-assessment-terraform/pull/5#discussion_r390723444), after I deployed https://github.com/cisagov/cool-assessment-terraform/pull/5, I noticed that one of the cloud-init scripts on the Guacamole instance was failing with this error:
```
botocore.exceptions.ClientError: An error occurred (AccessDenied)
when calling the AssumeRole operation:
User: arn:aws:sts::051445540311:assumed-role/guacamole_instance_role_default/i-059a2b3e51732a452
is not authorized to perform: sts:AssumeRole on resource:
arn:aws:iam::207871073513:role/ParameterStoreReadOnly-env0-VNC
```
It seems that the statement I removed in https://github.com/cisagov/cool-assessment-terraform/commit/f022950aadf7c6b11074df026198c284cc59fe49 was allowing the Guacamole instance to successfully assume the `ParameterStoreReadOnly-env0-VNC` role.  I'm pretty sure that statement was allowing any user from the `env0` account to assume the role and that apparently included the Guacamole instance profile.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
I applied the updated policy in this PR and verified that the newly-deployed Guacamole instance was able to assume the role in question and successfully run the cloud-init script that was previously failing.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
