### PR TITLE
Add DNS record for Guacamole instance

### DIFF
--- a/guacamole_route53.tf
+++ b/guacamole_route53.tf
@@ -1,0 +1,9 @@
+resource "aws_route53_record" "guacamole_A" {
+  provider = aws.dns_sharedservices
+
+  zone_id = local.cool_dns_private_zone.zone_id
+  name    = "guac.${var.assessment_account_name}.${var.cool_domain}"
+  type    = "A"
+  ttl     = var.dns_ttl
+  records = [aws_instance.guacamole.private_ip]
+}

--- a/locals.tf
+++ b/locals.tf
@@ -31,6 +31,8 @@ locals {
   # as assume role session names.
   caller_user_name = split("/", data.aws_caller_identity.current.arn)[1]
 
+  cool_dns_private_zone = data.terraform_remote_state.sharedservices_networking.outputs.private_zone
+
   cool_shared_services_cidr_block = data.terraform_remote_state.sharedservices_networking.outputs.vpc.cidr_block
 
   guacamole_fqdn = format("guac.%s.%s", var.assessment_account_name, var.cool_domain)

--- a/providers.tf
+++ b/providers.tf
@@ -6,6 +6,15 @@ provider "aws" {
   region = var.aws_region
 }
 
+provider "aws" {
+  alias  = "dns_sharedservices"
+  region = var.aws_region # route53 is global, but still required by Terraform
+  assume_role {
+    role_arn     = data.terraform_remote_state.sharedservices.outputs.provisionaccount_role.arn
+    session_name = local.caller_user_name
+  }
+}
+
 # The provider used to create roles that can read certificates from an S3 bucket
 provider "aws" {
   alias  = "provisioncertreadrole"

--- a/provisionassessment_policy.tf
+++ b/provisionassessment_policy.tf
@@ -76,6 +76,17 @@ data "aws_iam_policy_document" "provisionassessment_policy_doc" {
       data.terraform_remote_state.images.outputs.ami_kms_key.arn
     ]
   }
+
+  statement {
+    actions = [
+      "route53:AssociateVPCWithHostedZone",
+      "route53:DisassociateVPCFromHostedZone",
+    ]
+
+    resources = [
+      "arn:aws:route53:::hostedzone/${local.cool_dns_private_zone.zone_id}"
+    ]
+  }
 }
 
 resource "aws_iam_policy" "provisionassessment_policy" {

--- a/remote_states.tf
+++ b/remote_states.tf
@@ -78,6 +78,21 @@ data "terraform_remote_state" "master" {
   workspace = "production"
 }
 
+data "terraform_remote_state" "sharedservices" {
+  backend = "s3"
+
+  config = {
+    encrypt        = true
+    bucket         = "cisa-cool-terraform-state"
+    dynamodb_table = "terraform-state-lock"
+    profile        = "cool-terraform-backend"
+    region         = "us-east-1"
+    key            = "cool-accounts/shared_services.tfstate"
+  }
+
+  workspace = "production"
+}
+
 data "terraform_remote_state" "sharedservices_networking" {
   backend = "s3"
 

--- a/variables.tf
+++ b/variables.tf
@@ -60,6 +60,12 @@ variable "cool_domain" {
   default     = "cool.cyber.dhs.gov"
 }
 
+variable "dns_ttl" {
+  type        = number
+  description = "The TTL value to use for Route53 DNS records (e.g. 86400).  A smaller value may be useful when the DNS records are changing often, for example when testing."
+  default     = 60
+}
+
 # TODO: Generalize a way to automatically setup multiple Guac connections
 variable "guac_connection_name" {
   type        = string

--- a/vpc.tf
+++ b/vpc.tf
@@ -36,3 +36,28 @@ resource "aws_vpc_dhcp_options_association" "assessment" {
   dhcp_options_id = aws_vpc_dhcp_options.assessment.id
   vpc_id          = aws_vpc.assessment.id
 }
+
+# # Associate the COOL private DNS zone with this VPC
+#
+# Not available right now in Terraform
+# See https://github.com/cisagov/cool-assessment-terraform/issues/7
+# for details.
+#
+# For now, I manually executed:
+# aws route53 create-vpc-association-authorization \
+# --hosted-zone-id COOLPRIVATEZONEID \
+# --vpc VPCRegion=us-east-1,VPCId=vpc-MY_ENV_VPC_ID \
+# --profile cool-sharedservices-provisionaccount
+#
+# aws route53 associate-vpc-with-hosted-zone \
+# --hosted-zone-id COOLPRIVATEZONEID \
+# --vpc VPCRegion=us-east-1,VPCId=vpc-MY_ENV_VPC_ID \
+# --profile cool-MYENV-provisionaccount
+#
+#
+# resource "aws_route53_zone_association" "cool_private" {
+#   provider = aws.provisionassessment
+#
+#   vpc_id  = aws_vpc.assessment.id
+#   zone_id = local.cool_dns_private_zone.zone_id
+# }


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR creates a DNS record for the Guacamole instance in the COOL private DNS zone.

<!--- Describe your changes in detail -->

## 💭 Motivation and Context
We need this so that after a user gets on the VPN, they can access the appropriate Guacamole instance via DNS, e.g. `https://guac.env0.cool.cyber.dhs.gov`.

Note that part of this process had to be done manually - details can be found [here](https://github.com/cisagov/cool-assessment-terraform/blob/improvement/add_guac_to_private_dns/vpc.tf#L40-L63).

Resolves #2.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
After these changes were applied, I got on the COOL VPN and was able to successfully connect (via https and ssh) to the Guacamole instance in `env0` using its DNS name.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
