### PR TITLE
Add Kali instance to operations subnet

### DIFF
--- a/guacamole_iam.tf
+++ b/guacamole_iam.tf
@@ -38,7 +38,7 @@ resource "aws_iam_role_policy" "guacamole_assume_delegated_role_policy" {
 }
 
 # Attach the CloudWatch Agent policy to this role as well
-resource "aws_iam_role_policy_attachment" "cloudwatch_agent_policy_attachment" {
+resource "aws_iam_role_policy_attachment" "cloudwatch_agent_policy_attachment_guacamole" {
   provider = aws.provisionassessment
 
   role       = aws_iam_role.guacamole_instance_role.id

--- a/kali_ec2.tf
+++ b/kali_ec2.tf
@@ -1,0 +1,52 @@
+# The Kali AMI
+data "aws_ami" "kali" {
+  provider = aws.provisionassessment
+
+  filter {
+    name = "name"
+    values = [
+      "kali-hvm-*-x86_64-ebs"
+    ]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+
+  owners      = [local.images_account_id]
+  most_recent = true
+}
+
+# The Kali EC2 instance
+resource "aws_instance" "kali" {
+  provider = aws.provisionassessment
+
+  ami                         = data.aws_ami.kali.id
+  associate_public_ip_address = true
+  availability_zone           = "${var.aws_region}${var.aws_availability_zone}"
+  iam_instance_profile        = aws_iam_instance_profile.kali.name
+  instance_type               = "t2.medium"
+  subnet_id                   = aws_subnet.operations.id
+
+  root_block_device {
+    volume_type           = "gp2"
+    volume_size           = 128
+    delete_on_termination = true
+  }
+
+  # Not needed until we add in cloud-init tasks (e.g. disk setup)
+  # user_data_base64 = data.template_cloudinit_config.kali_cloud_init_tasks.rendered
+
+  vpc_security_group_ids = [
+    aws_security_group.operations.id,
+  ]
+
+  tags        = merge(var.tags, map("Name", "Kali"))
+  volume_tags = merge(var.tags, map("Name", "Kali"))
+}

--- a/kali_iam.tf
+++ b/kali_iam.tf
@@ -1,0 +1,60 @@
+# Create the IAM instance profile for the Kali EC2 server instance
+
+# The instance profile to be used
+resource "aws_iam_instance_profile" "kali" {
+  provider = aws.provisionassessment
+
+  name = "kali_instance_profile_${terraform.workspace}"
+  role = aws_iam_role.kali_instance_role.name
+}
+
+# The instance role
+resource "aws_iam_role" "kali_instance_role" {
+  provider = aws.provisionassessment
+
+  name               = "kali_instance_role_${terraform.workspace}"
+  assume_role_policy = data.aws_iam_policy_document.kali_assume_role_policy_doc.json
+}
+
+# TODO: Determine if needed:
+# resource "aws_iam_role_policy" "kali_assume_delegated_role_policy" {
+#   provider = aws.provisionassessment
+#
+#   name   = "assume_delegated_role_policy"
+#   role   = aws_iam_role.kali_instance_role.id
+#   policy = data.aws_iam_policy_document.kali_assume_delegated_role_policy_doc.json
+# }
+
+# Attach the CloudWatch Agent policy to this role as well
+resource "aws_iam_role_policy_attachment" "cloudwatch_agent_policy_attachment_kali" {
+  provider = aws.provisionassessment
+
+  role       = aws_iam_role.kali_instance_role.id
+  policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
+}
+
+################################
+# Define the role policies below
+################################
+
+data "aws_iam_policy_document" "kali_assume_role_policy_doc" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+    effect = "Allow"
+  }
+}
+
+# TODO: Determine if needed:
+# # Allow the Kali instance to assume the necessary roles:
+# data "aws_iam_policy_document" "kali_assume_delegated_role_policy_doc" {
+#   statement {
+#     actions = ["sts:AssumeRole"]
+#     resources = [
+#     ]
+#     effect = "Allow"
+#   }
+# }

--- a/kali_route53.tf
+++ b/kali_route53.tf
@@ -1,0 +1,10 @@
+# Private DNS A record for Kali instance
+resource "aws_route53_record" "kali_A" {
+  provider = aws.provisionassessment
+
+  zone_id = aws_route53_zone.assessment_private.zone_id
+  name    = "kali0.${aws_route53_zone.assessment_private.name}"
+  type    = "A"
+  ttl     = var.dns_ttl
+  records = [aws_instance.kali.private_ip]
+}

--- a/operations_sg_rules.tf
+++ b/operations_sg_rules.tf
@@ -1,0 +1,111 @@
+# Allow ingress from Guacamole instance via ssh
+# For: DevOps ssh access from Guacamole instance to Operations instance
+resource "aws_security_group_rule" "operations_ingress_from_guacamole_via_ssh" {
+  provider = aws.provisionassessment
+
+  security_group_id = aws_security_group.operations.id
+  type              = "ingress"
+  protocol          = "tcp"
+  cidr_blocks       = ["${aws_instance.guacamole.private_ip}/32"]
+  from_port         = 22
+  to_port           = 22
+}
+
+# Allow ingress from Guacamole instance via VNC
+# For: Assessment team VNC access from Guacamole instance to Operations instance
+resource "aws_security_group_rule" "operations_ingress_from_guacamole_via_vnc" {
+  provider = aws.provisionassessment
+
+  security_group_id = aws_security_group.operations.id
+  type              = "ingress"
+  protocol          = "tcp"
+  cidr_blocks       = ["${aws_instance.guacamole.private_ip}/32"]
+  from_port         = 5901
+  to_port           = 5901
+}
+
+# Allow ingress from anywhere via the TCP ports specified in
+# var.operations_subnet_inbound_tcp_ports_allowed
+# For: Assessment team operational use
+resource "aws_security_group_rule" "operations_ingress_from_anywhere_via_allowed_tcp_ports" {
+  provider = aws.provisionassessment
+  for_each = toset(var.operations_subnet_inbound_tcp_ports_allowed)
+
+  security_group_id = aws_security_group.operations.id
+  type              = "ingress"
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = each.value
+  to_port           = each.value
+}
+
+# Allow ingress from anywhere via ephemeral TCP/UDP ports below 3389 (1024-3388)
+# For: Assessment team operational use, but don't want to allow
+#      public access to RDP on port 3389
+resource "aws_security_group_rule" "operations_ingress_from_anywhere_via_ports_1024_thru_3388" {
+  provider = aws.provisionassessment
+  for_each = toset(local.tcp_and_udp)
+
+  security_group_id = aws_security_group.operations.id
+  type              = "ingress"
+  protocol          = each.value
+  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = 1024
+  to_port           = 3388
+}
+
+# Allow ingress from anywhere via ephemeral TCP/UDP ports 3390-5900
+# For: Assessment team operational use, but don't want to allow
+#      public access to RDP on port 3389 or VNC on port 5901
+resource "aws_security_group_rule" "operations_ingress_from_anywhere_via_ports_3390_thru_5900" {
+  provider = aws.provisionassessment
+  for_each = toset(local.tcp_and_udp)
+
+  security_group_id = aws_security_group.operations.id
+  type              = "ingress"
+  protocol          = each.value
+  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = 3390
+  to_port           = 5900
+}
+
+# Allow ingress from anywhere via ephemeral TCP/UDP ports above 5901 (5902-65535)
+# For: Assessment team operational use, but don't want to allow
+#      public access to VNC on port 5901
+resource "aws_security_group_rule" "operations_ingress_from_anywhere_via_ports_5901_thru_65535" {
+  provider = aws.provisionassessment
+  for_each = toset(local.tcp_and_udp)
+
+  security_group_id = aws_security_group.operations.id
+  type              = "ingress"
+  protocol          = each.value
+  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = 5901
+  to_port           = 65535
+}
+
+# Allow ingress from anywhere via ICMP
+# For: Assessment team operational use (e.g. ping responses)
+resource "aws_security_group_rule" "operations_ingress_from_anywhere_via_icmp" {
+  provider = aws.provisionassessment
+
+  security_group_id = aws_security_group.operations.id
+  type              = "ingress"
+  protocol          = "icmp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = -1
+  to_port           = -1
+}
+
+# Allow egress to anywhere via any protocol and port
+# For: Assessment team operational use
+resource "aws_security_group_rule" "operations_egress_to_anywhere_via_any_port" {
+  provider = aws.provisionassessment
+
+  security_group_id = aws_security_group.operations.id
+  type              = "egress"
+  protocol          = -1
+  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = -1
+  to_port           = -1
+}

--- a/provisionassessment_policy.tf
+++ b/provisionassessment_policy.tf
@@ -87,6 +87,24 @@ data "aws_iam_policy_document" "provisionassessment_policy_doc" {
       "arn:aws:route53:::hostedzone/${local.cool_dns_private_zone.zone_id}"
     ]
   }
+
+  statement {
+    actions = [
+      "route53:ChangeResourceRecordSets",
+      "route53:ChangeTagsForResource",
+      "route53:CreateHostedZone",
+      "route53:DeleteHostedZone",
+      "route53:GetChange",
+      "route53:GetHostedZone",
+      "route53:ListResourceRecordSets",
+      "route53:ListTagsForResource",
+      "route53:UpdateHostedZoneComment",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
 }
 
 resource "aws_iam_policy" "provisionassessment_policy" {

--- a/route53.tf
+++ b/route53.tf
@@ -1,0 +1,18 @@
+# Set up private DNS zone for this assessment
+resource "aws_route53_zone" "assessment_private" {
+  provider = aws.provisionassessment
+
+  name = "${var.private_domain}."
+
+  vpc {
+    vpc_id = aws_vpc.assessment.id
+  }
+
+  tags = merge(
+    var.tags,
+    {
+      "Name" = format("%s Private Zone", var.private_domain)
+    },
+  )
+  comment = "Terraform Workspace: ${terraform.workspace}"
+}


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR adds:
- A single Kali instance to the Operations subnet of the assessment VPC
- A private DNS zone with an A record for that Kali instance
- A reasonable first stab at rules for the Operations security group

Resolves #3.

<!--- Describe your changes in detail -->

## 💭 Motivation and Context
They want Kali, so heeeeeeeere's Kali!

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

`terraform apply` was successful in pre-Production.  I confirmed that the Kali instance was accessible and usable via a Guacamole VNC connection (including copy/paste and sftp file transfers from Guac to the Kali instance).

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)
![Screen Shot 2020-03-12 at 3 51 40 PM](https://user-images.githubusercontent.com/21343441/76561540-e3916b00-6479-11ea-8661-3a5c7ca86b25.png)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
