### PR TITLE
Handle Guacamole moving to port 443

### DIFF
--- a/desktop_gateway_sg_rules.tf
+++ b/desktop_gateway_sg_rules.tf
@@ -39,9 +39,9 @@ resource "aws_security_group_rule" "desktop_gw_egress_to_anywhere_via_https" {
 }
 
 # Allow ingress from COOL Shared Services VPN server CIDR block
-# via port 8443 (nginx/guacamole web)
+# via port 443 (nginx/guacamole web)
 # For: Assessment team access to Guacamole web client
-resource "aws_security_group_rule" "desktop_gw_ingress_from_trusted_via_port_8443" {
+resource "aws_security_group_rule" "desktop_gw_ingress_from_trusted_via_port_443" {
   provider = aws.provisionassessment
 
   security_group_id = aws_security_group.desktop_gateway.id
@@ -49,8 +49,8 @@ resource "aws_security_group_rule" "desktop_gw_ingress_from_trusted_via_port_844
   protocol          = "tcp"
   cidr_blocks       = [local.vpn_server_cidr_block]
   # ipv6_cidr_blocks  = TBD
-  from_port = 8443
-  to_port   = 8443
+  from_port = 443
+  to_port   = 443
 }
 
 # Allow egress via VNC to the Operations subnet
@@ -67,10 +67,9 @@ resource "aws_security_group_rule" "desktop_gw_egress_to_ops_via_vnc" {
   to_port           = 5901
 }
 
-# Allow ingress from anywhere via ephemeral ports below 8443 (1024-8442)
-# We do not want to allow everyone to hit Guacamole on port 8443
+# Allow ingress from anywhere via ephemeral ports
 # For: Guacamole fetches its SSL certificate via boto3 (which uses HTTPS)
-resource "aws_security_group_rule" "desktop_gw_ingress_from_anywhere_via_ports_1024_thru_8442" {
+resource "aws_security_group_rule" "desktop_gw_ingress_from_anywhere_via_ephemeral_ports" {
   provider = aws.provisionassessment
 
   security_group_id = aws_security_group.desktop_gateway.id
@@ -78,19 +77,5 @@ resource "aws_security_group_rule" "desktop_gw_ingress_from_anywhere_via_ports_1
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
   from_port         = 1024
-  to_port           = 8442
-}
-
-# Allow ingress from anywhere via ephemeral ports above 8443 (8444-65535)
-# We do not want to allow everyone to hit Guacamole on port 8443
-# For: Guacamole fetches its SSL certificate via boto3 (which uses HTTPS)
-resource "aws_security_group_rule" "desktop_gw_ingress_from_anywhere_via_ports_8444_thru_65535" {
-  provider = aws.provisionassessment
-
-  security_group_id = aws_security_group.desktop_gateway.id
-  type              = "ingress"
-  protocol          = "tcp"
-  cidr_blocks       = ["0.0.0.0/0"]
-  from_port         = 8444
   to_port           = 65535
 }

--- a/private_acl_rules.tf
+++ b/private_acl_rules.tf
@@ -14,6 +14,22 @@ resource "aws_network_acl_rule" "private_ingress_from_cool_via_ssh" {
   to_port        = 22
 }
 
+# Allow ingress from COOL Shared Services VPN server CIDR block via https
+# For: Assessment team access to guacamole web client
+resource "aws_network_acl_rule" "private_ingress_from_cool_via_https" {
+  provider = aws.provisionassessment
+  for_each = toset(var.private_subnet_cidr_blocks)
+
+  network_acl_id = aws_network_acl.private[each.value].id
+  egress         = false
+  protocol       = "tcp"
+  rule_number    = 102 + index(var.private_subnet_cidr_blocks, each.value)
+  rule_action    = "allow"
+  cidr_block     = local.vpn_server_cidr_block
+  from_port      = 443
+  to_port        = 443
+}
+
 # Allow egress to anywhere via HTTPS
 # For: Guacamole fetches its SSL certificate via boto3 (which uses HTTPS)
 resource "aws_network_acl_rule" "private_egress_to_anywhere_via_https" {
@@ -23,7 +39,7 @@ resource "aws_network_acl_rule" "private_egress_to_anywhere_via_https" {
   network_acl_id = aws_network_acl.private[each.value].id
   egress         = true
   protocol       = "tcp"
-  rule_number    = 102 + index(var.private_subnet_cidr_blocks, each.value)
+  rule_number    = 104 + index(var.private_subnet_cidr_blocks, each.value)
   rule_action    = "allow"
   cidr_block     = "0.0.0.0/0"
   from_port      = 443
@@ -39,7 +55,7 @@ resource "aws_network_acl_rule" "private_egress_to_cool_via_ephemeral_ports" {
   network_acl_id = aws_network_acl.private[each.value].id
   egress         = true
   protocol       = "tcp"
-  rule_number    = 104 + index(var.private_subnet_cidr_blocks, each.value)
+  rule_number    = 106 + index(var.private_subnet_cidr_blocks, each.value)
   rule_action    = "allow"
   cidr_block     = local.cool_shared_services_cidr_block
   from_port      = 1024
@@ -55,7 +71,7 @@ resource "aws_network_acl_rule" "private_egress_to_operations_via_ssh" {
   network_acl_id = aws_network_acl.private[each.value].id
   egress         = true
   protocol       = "tcp"
-  rule_number    = 106 + index(var.private_subnet_cidr_blocks, each.value)
+  rule_number    = 108 + index(var.private_subnet_cidr_blocks, each.value)
   rule_action    = "allow"
   cidr_block     = aws_subnet.operations.cidr_block
   from_port      = 22
@@ -72,7 +88,7 @@ resource "aws_network_acl_rule" "private_ingress_from_operations_via_ephemeral_p
   network_acl_id = aws_network_acl.private[each.value].id
   egress         = false
   protocol       = "tcp"
-  rule_number    = 108 + index(var.private_subnet_cidr_blocks, each.value)
+  rule_number    = 110 + index(var.private_subnet_cidr_blocks, each.value)
   rule_action    = "allow"
   cidr_block     = aws_subnet.operations.cidr_block
   from_port      = 1024
@@ -80,8 +96,7 @@ resource "aws_network_acl_rule" "private_ingress_from_operations_via_ephemeral_p
 }
 
 # Allow ingress from anywhere via ephemeral ports
-# For: Assessment team access to guacamole web client
-#      Guacamole fetches its SSL certificate via boto3 (which uses HTTPS)
+# For: Guacamole fetches its SSL certificate via boto3 (which uses HTTPS)
 resource "aws_network_acl_rule" "private_ingress_from_anywhere_via_ephemeral_ports" {
   provider = aws.provisionassessment
   for_each = toset(var.private_subnet_cidr_blocks)
@@ -89,7 +104,7 @@ resource "aws_network_acl_rule" "private_ingress_from_anywhere_via_ephemeral_por
   network_acl_id = aws_network_acl.private[each.value].id
   egress         = false
   protocol       = "tcp"
-  rule_number    = 110 + index(var.private_subnet_cidr_blocks, each.value)
+  rule_number    = 112 + index(var.private_subnet_cidr_blocks, each.value)
   rule_action    = "allow"
   cidr_block     = "0.0.0.0/0"
   from_port      = 1024


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
In https://github.com/cisagov/guacamole-composition/pull/3, the port to access Guacamole changed from 8443 to 443.  This PR adjusts the security group and network ACL rules to account for that change.

<!--- Describe your changes in detail -->

## 💭 Motivation and Context
Without this change, nobody can access Guacamole, which would be less than ideal.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
After applying this terraform in `env0`, I verified that Guacamole is accessible from the COOL VPN on port 443.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)
![Screen Shot 2020-03-13 at 2 14 13 PM](https://user-images.githubusercontent.com/21343441/76648376-f87f0480-6534-11ea-984a-acad54204c87.png)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
