### PR TITLE
Auto-create Guacamole connection to Kali instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ Coming soon!
 | aws_region | The AWS region to deploy into (e.g. us-east-1). | string | `us-east-1` | no |
 | cert_bucket_name | The name of the AWS S3 bucket where certificates are stored. | string | `cisa-cool-certificates` | no |
 | cool_domain | The domain where the COOL resources reside (e.g. "cool.cyber.dhs.gov"). | string | `cool.cyber.dhs.gov` | no |
-| guac_connection_name | The desired name of the Guacamole connection to the TBD instance. | string | `TBD` | no |
-| guac_connection_setup_filename | The name of the file to create on the Guacamole instance containing SQL instructions to populate any desired Guacamole connections.  NOTE: Postgres processes these files alphabetically, so it's important to name this file so it runs after the file that defines the Guacamole tables and users ("00_initdb.sql"). | string | `01_setup_guac_connections.sql` | no |
 | guac_connection_setup_path | The full path to the dbinit directory where <guac_connection_setup_filename> must be stored in order to work properly (e.g. "/var/guacamole/dbinit"). | string | `/var/guacamole/dbinit` | no |
 | operations_subnet_cidr_block | The operations subnet CIDR block for this assessment (e.g. "10.10.0.0/24"). | string | | yes |
 | operations_subnet_inbound_tcp_ports_allowed | The list of TCP ports allowed inbound (from anywhere) to the operations subnet (e.g. ["80", "443"]). | list(string) | `["80", "443"]` | no |

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Coming soon!
 | aws_region | The AWS region to deploy into (e.g. us-east-1). | string | `us-east-1` | no |
 | cert_bucket_name | The name of the AWS S3 bucket where certificates are stored. | string | `cisa-cool-certificates` | no |
 | cool_domain | The domain where the COOL resources reside (e.g. "cool.cyber.dhs.gov"). | string | `cool.cyber.dhs.gov` | no |
-| guac_connection_setup_path | The full path to the dbinit directory where <guac_connection_setup_filename> must be stored in order to work properly (e.g. "/var/guacamole/dbinit"). | string | `/var/guacamole/dbinit` | no |
+| guac_connection_setup_path | The full path to the dbinit directory where initialization files must be stored in order to work properly (e.g. "/var/guacamole/dbinit"). | string | `/var/guacamole/dbinit` | no |
 | operations_subnet_cidr_block | The operations subnet CIDR block for this assessment (e.g. "10.10.0.0/24"). | string | | yes |
 | operations_subnet_inbound_tcp_ports_allowed | The list of TCP ports allowed inbound (from anywhere) to the operations subnet (e.g. ["80", "443"]). | list(string) | `["80", "443"]` | no |
 | private_domain | The local domain to use for this assessment (e.g. "env0"). | string | | yes |

--- a/cloud-init/render-guac-connection-sql-template.py
+++ b/cloud-init/render-guac-connection-sql-template.py
@@ -14,6 +14,9 @@ import boto3
 import pystache
 
 SQL_TEMPLATE = "${sql_template_fullpath}"
+# NOTE: Postgres processes initialization files alphabetically, so it's
+# important to name this file so it runs after the file that defines the
+# Guacamole tables and users ("00_initdb.sql").
 SQL_OUTPUT_FILE = "${guac_connection_setup_path}/${guac_connection_setup_filename}"
 
 # Inputs from terraform

--- a/cloud-init/write-guac-connection-sql-template.tpl.yml
+++ b/cloud-init/write-guac-connection-sql-template.tpl.yml
@@ -11,14 +11,14 @@ write_files:
     owner: root:root
     content: |
       --
-      -- Create connection for instance
+      -- Create connection for ${instance_hostname} instance
       --
 
       INSERT INTO guacamole_connection (
         connection_name, protocol, max_connections, max_connections_per_user,
         proxy_port, proxy_hostname, proxy_encryption_method)
       VALUES (
-        '${guac_connection_name}', 'vnc', 10, 10, 4822,
+        '${instance_hostname}', 'vnc', 10, 10, 4822,
         'guacd', 'NONE');
 
       --
@@ -29,45 +29,45 @@ write_files:
         connection_id, parameter_name, parameter_value)
       SELECT connection_id, 'cursor', 'local'
       FROM guacamole_connection
-      WHERE connection_name = '${guac_connection_name}'
+      WHERE connection_name = '${instance_hostname}'
         UNION ALL
       SELECT
         connection_id, 'sftp-directory', '/home/{{ vnc_username }}/Documents'
       FROM guacamole_connection
-      WHERE connection_name = '${guac_connection_name}'
+      WHERE connection_name = '${instance_hostname}'
         UNION ALL
       SELECT connection_id, 'sftp-username', '{{ vnc_username }}'
       FROM guacamole_connection
-      WHERE connection_name = '${guac_connection_name}'
+      WHERE connection_name = '${instance_hostname}'
         UNION ALL
       SELECT connection_id, 'sftp-private-key', '{{ vnc_user_private_ssh_key }}'
       FROM guacamole_connection
-      WHERE connection_name = '${guac_connection_name}'
+      WHERE connection_name = '${instance_hostname}'
         UNION ALL
       SELECT connection_id, 'sftp-server-alive-interval', '60'
       FROM guacamole_connection
-      WHERE connection_name = '${guac_connection_name}'
+      WHERE connection_name = '${instance_hostname}'
         UNION ALL
       SELECT connection_id, 'sftp-root-directory', '/home/{{ vnc_username }}/'
       FROM guacamole_connection
-      WHERE connection_name = '${guac_connection_name}'
+      WHERE connection_name = '${instance_hostname}'
         UNION ALL
       SELECT connection_id, 'enable-sftp', 'true'
       FROM guacamole_connection
-      WHERE connection_name = '${guac_connection_name}'
+      WHERE connection_name = '${instance_hostname}'
         UNION ALL
       SELECT connection_id, 'color-depth', '24'
       FROM guacamole_connection
-      WHERE connection_name = '${guac_connection_name}'
+      WHERE connection_name = '${instance_hostname}'
         UNION ALL
-      SELECT connection_id, 'hostname', 'TBD.${private_domain}'
+      SELECT connection_id, 'hostname', '${instance_hostname}.${private_domain}'
       FROM guacamole_connection
-      WHERE connection_name = '${guac_connection_name}'
+      WHERE connection_name = '${instance_hostname}'
         UNION ALL
       SELECT connection_id, 'password', '{{ vnc_password }}'
       FROM guacamole_connection
-      WHERE connection_name = '${guac_connection_name}'
+      WHERE connection_name = '${instance_hostname}'
         UNION ALL
       SELECT connection_id, 'port', '5901'
       FROM guacamole_connection
-      WHERE connection_name = '${guac_connection_name}';
+      WHERE connection_name = '${instance_hostname}';

--- a/guacamole_cloud_init.tf
+++ b/guacamole_cloud_init.tf
@@ -21,31 +21,36 @@ data "template_cloudinit_config" "guacamole_cloud_init_tasks" {
   }
 
   # TODO: Make this more generalized and able to support a variety of connections
+  # Set up Guacamole connection to Kali instance
   part {
-    filename     = "write-guac-connection-sql-template.yml"
+    filename     = "write-kali-guac-connection-sql-template.yml"
     content_type = "text/cloud-config"
     content = templatefile(
       "${path.module}/cloud-init/write-guac-connection-sql-template.tpl.yml", {
-        guac_connection_name  = var.guac_connection_name
+        instance_hostname     = "kali0"
         private_domain        = var.private_domain
-        sql_template_fullpath = "/root/guacamole_connection_template.sql"
+        sql_template_fullpath = "/root/kali_guacamole_connection_template.sql"
     })
   }
 
   # TODO: Make this more generalized and able to support a variety of connections
+  # Set up Guacamole connection to Kali instance
+  # NOTE: Postgres processes initialization files alphabetically, so it's
+  # important to name guac_connection_setup_filename so it runs after the
+  # file that defines the Guacamole tables and users ("00_initdb.sql").
   part {
     filename     = "render-guac-connection-sql-template.py"
     content_type = "text/x-shellscript"
     content = templatefile(
       "${path.module}/cloud-init/render-guac-connection-sql-template.py", {
         aws_region                       = var.aws_region
-        guac_connection_setup_filename   = var.guac_connection_setup_filename
+        guac_connection_setup_filename   = "01_setup_kali_guac_connection.sql"
         guac_connection_setup_path       = var.guac_connection_setup_path
         ssm_vnc_read_role_arn            = aws_iam_role.vnc_parameterstorereadonly_role.arn
         ssm_key_vnc_password             = var.ssm_key_vnc_password
         ssm_key_vnc_user                 = var.ssm_key_vnc_username
         ssm_key_vnc_user_private_ssh_key = var.ssm_key_vnc_user_private_ssh_key
-        sql_template_fullpath            = "/root/guacamole_connection_template.sql"
+        sql_template_fullpath            = "/root/kali_guacamole_connection_template.sql"
     })
   }
 }

--- a/guacamole_cloud_init.tf
+++ b/guacamole_cloud_init.tf
@@ -39,7 +39,7 @@ data "template_cloudinit_config" "guacamole_cloud_init_tasks" {
   # important to name guac_connection_setup_filename so it runs after the
   # file that defines the Guacamole tables and users ("00_initdb.sql").
   part {
-    filename     = "render-guac-connection-sql-template.py"
+    filename     = "render-kali-guac-connection-sql-template.py"
     content_type = "text/x-shellscript"
     content = templatefile(
       "${path.module}/cloud-init/render-guac-connection-sql-template.py", {

--- a/variables.tf
+++ b/variables.tf
@@ -68,7 +68,7 @@ variable "dns_ttl" {
 
 variable "guac_connection_setup_path" {
   type        = string
-  description = "The full path to the dbinit directory where <guac_connection_setup_filename> must be stored in order to work properly. (e.g. \"/var/guacamole/dbinit\")"
+  description = "The full path to the dbinit directory where initialization files must be stored in order to work properly. (e.g. \"/var/guacamole/dbinit\")"
   default     = "/var/guacamole/dbinit"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -66,19 +66,6 @@ variable "dns_ttl" {
   default     = 60
 }
 
-# TODO: Generalize a way to automatically setup multiple Guac connections
-variable "guac_connection_name" {
-  type        = string
-  description = "The desired name of the Guacamole connection to the TBD instance"
-  default     = "TBD"
-}
-
-variable "guac_connection_setup_filename" {
-  type        = string
-  description = "The name of the file to create on the Guacamole instance containing SQL instructions to populate any desired Guacamole connections.  NOTE: Postgres processes these files alphabetically, so it's important to name this file so it runs after the file that defines the Guacamole tables and users (\"00_initdb.sql\")."
-  default     = "01_setup_guac_connections.sql"
-}
-
 variable "guac_connection_setup_path" {
   type        = string
   description = "The full path to the dbinit directory where <guac_connection_setup_filename> must be stored in order to work properly. (e.g. \"/var/guacamole/dbinit\")"


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR automatically sets up a Guacamole connection to the Kali instance when the Guacamole instance is deployed.

<!--- Describe your changes in detail -->

## 💭 Motivation and Context
We don't want to have to manually set up Guacamole connections to the various Operations instances, so let's do it automatically!  This code will need further refinement in order to support multiple instances (e.g. more than one Kali) and multiple instance types (e.g. phishing or Windows), but this should suffice for our current milestone.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
I deployed this Terraform and verified that the Guacamole connection to `kali0` was indeed created automatically.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
