### PR TITLE
Use an isolated Transit Gateway route table instead of the default one

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -55,6 +55,9 @@ locals {
 
   # The ID of the Transit Gateway in the Shared Services account
   transit_gateway_id = data.terraform_remote_state.sharedservices_networking.outputs.transit_gateway.id
+  # The ID of the route table to be associated with the Transit
+  # Gateway attachment for this account.
+  transit_gateway_route_table_id = data.terraform_remote_state.sharedservices_networking.outputs.transit_gateway_attachment_route_tables[local.assessment_account_id]
 
   # Find the new Users account by name and email.
   users_account_id = [

--- a/transitgateway.tf
+++ b/transitgateway.tf
@@ -1,18 +1,30 @@
 # ------------------------------------------------------------------------------
 # Attach VPC to the Transit Gateway in the Shared Services account
-# (see https://github.com/cisagov/cool-sharedservices-networking)
+# (see https://github.com/cisagov/cool-sharedservices-networking).
+#
 # Note that this attachment will be automatically accepted as long
 # as the Transit Gateway was set up with:
 #  auto_accept_shared_attachments = "enable"
+#
+# Note also that we are associating to the TGW VPC attachment a
+# particular route table.  This route table allows communication to
+# the Shared Services account, but nowhere else.  This serves to
+# isolate the assessment accounts from each other.
 # ------------------------------------------------------------------------------
 
 resource "aws_ec2_transit_gateway_vpc_attachment" "assessment" {
   provider = aws.provisionassessment
 
-  # All subnets of the VPC are currently in the same availability zone, so it
-  # doesn't matter which subnet ID we use for the Transit Gateway attachment
+  # All subnets of the VPC are currently in the same availability
+  # zone, so it doesn't matter which subnet ID we use for the Transit
+  # Gateway attachment.
   subnet_ids         = [aws_subnet.operations.id]
   tags               = var.tags
   transit_gateway_id = local.transit_gateway_id
   vpc_id             = aws_vpc.assessment.id
+}
+
+resource "aws_ec2_transit_gateway_route_table_association" "association" {
+  transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.assessment.id
+  transit_gateway_route_table_id = local.transit_gateway_route_table_id
 }

--- a/transitgateway.tf
+++ b/transitgateway.tf
@@ -28,3 +28,10 @@ resource "aws_ec2_transit_gateway_route_table_association" "association" {
   transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.assessment.id
   transit_gateway_route_table_id = local.transit_gateway_route_table_id
 }
+
+# Add a route to the assessment VPC.
+resource "aws_ec2_transit_gateway_route" "assessment_route" {
+  destination_cidr_block         = aws_vpc.assessment.cidr_block
+  transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.assessment.id
+  transit_gateway_route_table_id = local.transit_gateway_route_table_id
+}


### PR DESCRIPTION
## 🗣 Description

In this PR I modify the Terraform code to use a Transit Gateway route table different from the default one.  This route table only allows traffic between the assessment VPC and the Shared Services VPC.

## 💭 Motivation and Context

We want assessment environments to be isolated from each other, and this is precisely what these changes achieve when combined with cisagov/cool-sharedservices-networking#16.

This PR is linked to cisagov/cool-sharedservices-networking#9.

## 🧪 Testing

All pre-commit hooks pass.  Once we have a COOL staging environment up and running then I can perform a real deployment test.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
