### PR TITLE
Fix incorrect SG rule allowing access to port 5901 (VNC)

### DIFF
--- a/operations_sg_rules.tf
+++ b/operations_sg_rules.tf
@@ -72,7 +72,7 @@ resource "aws_security_group_rule" "operations_ingress_from_anywhere_via_ports_3
 # Allow ingress from anywhere via ephemeral TCP/UDP ports above 5901 (5902-65535)
 # For: Assessment team operational use, but don't want to allow
 #      public access to VNC on port 5901
-resource "aws_security_group_rule" "operations_ingress_from_anywhere_via_ports_5901_thru_65535" {
+resource "aws_security_group_rule" "operations_ingress_from_anywhere_via_ports_5902_thru_65535" {
   provider = aws.provisionassessment
   for_each = toset(local.tcp_and_udp)
 
@@ -80,7 +80,7 @@ resource "aws_security_group_rule" "operations_ingress_from_anywhere_via_ports_5
   type              = "ingress"
   protocol          = each.value
   cidr_blocks       = ["0.0.0.0/0"]
-  from_port         = 5901
+  from_port         = 5902
   to_port           = 65535
 }
 


### PR DESCRIPTION

# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR changes the security group rules in the Operations SG so that port 5901 is only accessible from the Guacamole instance.

<!--- Describe your changes in detail -->

## 💭 Motivation and Context
This was the original intent of this security group rule, however it was accidentally created incorrectly, allowing access to port 5901 from anywhere.  Since the corresponding network ACL was set up correctly (deny public access to port 5901), the only way this could've been taken advantage of was from within the Operations security group...

...And that is exactly how it was exploited, as @KyleEvers helpfully pointed out that the Kali instances could VNC to one another.  Big thanks to @KyleEvers for noticing this so quickly and allowing us to fix it!

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
From the `kali0.env0` instance, I verified that I was able to VNC to `kali1.env0`.  Then I applied the Terraform changes in this PR and confirmed that I was no longer able to VNC from `kali0` to `kali1`.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
