### PR TITLE
Support multiple operations instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,62 @@
 This project is used to create an operational assessment environment in
 the COOL environment.
 
+## Pre-requisites ##
+
+- [Terraform](https://www.terraform.io/) installed on your system.
+- An accessible AWS S3 bucket to store Terraform state
+  (specified [here](backend.tf)).
+- An accessible AWS DynamoDB database to store the Terraform state lock
+  (specified [here](backend.tf)).
+- Access to all of the Terraform remote states specified in
+  [the remote states file](remote_states.tf).
+- Accept the terms for any AWS Marketplace subscriptions to be used by the
+  operations instances in your assessment environment (must be done in
+  the AWS account hosting the assessment environment):
+  - [Kali Linux](https://console.aws.amazon.com/marketplace/home?#/subscriptions/U1VCU0NSSVBUSU9OQEBAOGI3ZmRmZTMtOGNkNS00M2NjLThlNWUtNGUwZTdmNDEzOWQ1)
+- Access to AWS AMIs for [Guacamole](https://github.com/cisagov/guacamole-packer)
+  and any other operations instance types used in your assessment.
+- OpenSSL server certificate and private key for the Guacamole instance
+  in your assessment environment, stored in an accessible AWS S3 bucket;
+  this can be easily created via
+  [certboto-docker](https://github.com/cisagov/certboto-docker)
+  or a similar tool.
+- A Terraform [variables](variables.tf) file customized for your
+  assessment environment, for example:
+
+  ```console
+  assessment_account_name = "env0"
+  private_domain          = "env0"
+
+  vpc_cidr_block               = "10.224.0.0/21"
+  operations_subnet_cidr_block = "10.224.0.0/24"
+  private_subnet_cidr_blocks   = ["10.224.1.0/24", "10.224.2.0/24"]
+
+  tags = {
+    Team        = "VM Fusion - Development"
+    Application = "COOL - env0 Account"
+    Workspace   = "env0"
+  }
+  ```
+
 ## Building the Terraform-based infrastructure ##
 
-Coming soon!
+1. Create a Terraform workspace (if you haven't already done so) for
+   your assessment by running `terraform workspace new <workspace_name>`.
+1. Create a `<workspace_name>.tfvars` file with all of the required
+   variables (see [Inputs](#Inputs) below for details).
+1. Run the command `terraform init`.
+1. Add all necessary permissions by running the command:
+
+   ```console
+   terraform apply -var-file=<workspace_name>.tfvars --target=aws_iam_policy.provisionassessment_policy --target=aws_iam_role_policy_attachment.provisionassessment_policy_attachment
+   ```
+
+1. Create all remaining Terraform infrastructure by running the command:
+
+   ```console
+   terraform apply -var-file=<workspace_name>.tfvars
+   ```
 
 ## Inputs ##
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Coming soon!
 
 | Name | Description |
 |------|-------------|
-| TBD | TBD |
+| remote_desktop_url | The URL of the remote desktop gateway (Guacamole) for this assessment. |
 
 ## Contributing ##
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Coming soon!
 | cert_bucket_name | The name of the AWS S3 bucket where certificates are stored. | string | `cisa-cool-certificates` | no |
 | cool_domain | The domain where the COOL resources reside (e.g. "cool.cyber.dhs.gov"). | string | `cool.cyber.dhs.gov` | no |
 | guac_connection_setup_path | The full path to the dbinit directory where initialization files must be stored in order to work properly (e.g. "/var/guacamole/dbinit"). | string | `/var/guacamole/dbinit` | no |
+| operations_instance_counts | A map specifying how many instances of each type should be created in the operations subnet (e.g. {\ "kali\": 1 }). | map(number) | `{ "kali": 1 }` | no |
 | operations_subnet_cidr_block | The operations subnet CIDR block for this assessment (e.g. "10.10.0.0/24"). | string | | yes |
 | operations_subnet_inbound_tcp_ports_allowed | The list of TCP ports allowed inbound (from anywhere) to the operations subnet (e.g. ["80", "443"]). | list(string) | `["80", "443"]` | no |
 | private_domain | The local domain to use for this assessment (e.g. "env0"). | string | | yes |

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ the COOL environment.
 | cert_bucket_name | The name of the AWS S3 bucket where certificates are stored. | string | `cisa-cool-certificates` | no |
 | cool_domain | The domain where the COOL resources reside (e.g. "cool.cyber.dhs.gov"). | string | `cool.cyber.dhs.gov` | no |
 | guac_connection_setup_path | The full path to the dbinit directory where initialization files must be stored in order to work properly (e.g. "/var/guacamole/dbinit"). | string | `/var/guacamole/dbinit` | no |
-| operations_instance_counts | A map specifying how many instances of each type should be created in the operations subnet (e.g. {\ "kali\": 1 }). | map(number) | `{ "kali": 1 }` | no |
+| operations_instance_counts | A map specifying how many instances of each type should be created in the operations subnet (e.g. { "kali": 1 }).  The currently-supported instance keys are: ["kali"]. | map(number) | `{ "kali": 1 }` | no |
 | operations_subnet_cidr_block | The operations subnet CIDR block for this assessment (e.g. "10.10.0.0/24"). | string | | yes |
 | operations_subnet_inbound_tcp_ports_allowed | The list of TCP ports allowed inbound (from anywhere) to the operations subnet (e.g. ["80", "443"]). | list(string) | `["80", "443"]` | no |
 | private_domain | The local domain to use for this assessment (e.g. "env0"). | string | | yes |

--- a/kali_ec2.tf
+++ b/kali_ec2.tf
@@ -25,6 +25,7 @@ data "aws_ami" "kali" {
 
 # The Kali EC2 instance
 resource "aws_instance" "kali" {
+  count    = var.operations_instance_counts["kali"]
   provider = aws.provisionassessment
 
   ami                         = data.aws_ami.kali.id

--- a/kali_route53.tf
+++ b/kali_route53.tf
@@ -1,10 +1,11 @@
 # Private DNS A record for Kali instance
 resource "aws_route53_record" "kali_A" {
+  count    = var.operations_instance_counts["kali"]
   provider = aws.provisionassessment
 
   zone_id = aws_route53_zone.assessment_private.zone_id
-  name    = "kali0.${aws_route53_zone.assessment_private.name}"
+  name    = "kali${count.index}.${aws_route53_zone.assessment_private.name}"
   type    = "A"
   ttl     = var.dns_ttl
-  records = [aws_instance.kali.private_ip]
+  records = [aws_instance.kali[count.index].private_ip]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,4 @@
+output "remote_desktop_url" {
+  value       = "https://${aws_route53_record.guacamole_A.name}"
+  description = "The URL of the remote desktop gateway (Guacamole) for this assessment."
+}

--- a/variables.tf
+++ b/variables.tf
@@ -72,6 +72,12 @@ variable "guac_connection_setup_path" {
   default     = "/var/guacamole/dbinit"
 }
 
+variable "operations_instance_counts" {
+  type        = map(number)
+  description = "A map specifying how many instances of each type should be created in the operations subnet (e.g. { \"kali\": 1 })."
+  default     = { "kali" : 1 }
+}
+
 variable "operations_subnet_inbound_tcp_ports_allowed" {
   type        = list(string)
   description = "The list of TCP ports allowed inbound (from anywhere) to the operations subnet (e.g. [\"80\", \"443\"])."

--- a/variables.tf
+++ b/variables.tf
@@ -74,7 +74,7 @@ variable "guac_connection_setup_path" {
 
 variable "operations_instance_counts" {
   type        = map(number)
-  description = "A map specifying how many instances of each type should be created in the operations subnet (e.g. { \"kali\": 1 })."
+  description = "A map specifying how many instances of each type should be created in the operations subnet (e.g. { \"kali\": 1 }).  The currently-supported instance keys are: [\"kali\"]."
   default     = { "kali" : 1 }
 }
 


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR adds support for multiple instances within the Operations subnet.  It also adds a Terraform output for the remote desktop (Guacamole) URL, as well as some more useful info in the README.

<!--- Describe your changes in detail -->

## 💭 Motivation and Context
There was a request to spin up more than one Kali instance in the Operations subnet.  This PR enables that in a flexible way that will support additional types of instances (phishing, Cobalt Strike, Windows, etc.) in the future.

I also took this opportunity to update the README to be a bit more comprehensive and also to add a useful output with the Guacamole URL.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
All pre-commit tests passed and all of these changes were successfully applied in the COOL.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
