### PR TITLE
Stop hardcoding workspace name in remote state configurations

### DIFF
--- a/remote_states.tf
+++ b/remote_states.tf
@@ -44,6 +44,9 @@ data "terraform_remote_state" "dynamic_assessment" {
     key            = "cool-accounts/dynamic.tfstate"
   }
 
+  # Note that this workspace is different from all the others.  For
+  # the others we want production, staging, etc.  Here, though, we
+  # want (for example) env0, (for production), env0-staging, etc.
   workspace = local.workspace_name
 }
 

--- a/remote_states.tf
+++ b/remote_states.tf
@@ -15,7 +15,7 @@ data "terraform_remote_state" "dns_certboto" {
     key            = "cool-dns-certboto/terraform.tfstate"
   }
 
-  workspace = "production"
+  workspace = terraform.workspace
 }
 
 data "terraform_remote_state" "dynamic_assessment" {
@@ -45,7 +45,7 @@ data "terraform_remote_state" "images" {
     key            = "cool-accounts/images.tfstate"
   }
 
-  workspace = "production"
+  workspace = terraform.workspace
 }
 
 data "terraform_remote_state" "images_parameterstore" {
@@ -60,7 +60,7 @@ data "terraform_remote_state" "images_parameterstore" {
     key            = "cool-images-parameterstore/terraform.tfstate"
   }
 
-  workspace = "production"
+  workspace = terraform.workspace
 }
 
 data "terraform_remote_state" "master" {
@@ -75,7 +75,7 @@ data "terraform_remote_state" "master" {
     key            = "cool-accounts/master.tfstate"
   }
 
-  workspace = "production"
+  workspace = terraform.workspace
 }
 
 data "terraform_remote_state" "sharedservices" {
@@ -90,7 +90,7 @@ data "terraform_remote_state" "sharedservices" {
     key            = "cool-accounts/shared_services.tfstate"
   }
 
-  workspace = "production"
+  workspace = terraform.workspace
 }
 
 data "terraform_remote_state" "sharedservices_networking" {
@@ -105,5 +105,5 @@ data "terraform_remote_state" "sharedservices_networking" {
     key            = "cool-sharedservices-networking/terraform.tfstate"
   }
 
-  workspace = "production"
+  workspace = terraform.workspace
 }

--- a/remote_states.tf
+++ b/remote_states.tf
@@ -3,6 +3,20 @@
 # root-level outputs of one or more Terraform configurations as input data
 # for this configuration.
 # ------------------------------------------------------------------------------
+
+locals {
+  # If this is a non-production account, for example, then there will
+  # be a space followed by a string such as "Staging" to denote the
+  # account type.  If it is a production account then there is no
+  # space and no extra string.
+  assessment_account_name_split = split(var.assessment_account_name, " ")
+  production_workspace          = length(local.assessment_account_name_split) == 1
+  # e.g. production, staging, etc.
+  workspace_type = local.production_workspace ? "production" : lower(local.assessment_account_name_split[1])
+  # e.g. env0 (for production), env0-staging, etc.
+  workspace_name = local.production_workspace ? var.assessment_account_name : "${var.assessment_account_name}-${local.workspace_type}"
+}
+
 data "terraform_remote_state" "dns_certboto" {
   backend = "s3"
 
@@ -15,7 +29,7 @@ data "terraform_remote_state" "dns_certboto" {
     key            = "cool-dns-certboto/terraform.tfstate"
   }
 
-  workspace = terraform.workspace
+  workspace = local.workspace_type
 }
 
 data "terraform_remote_state" "dynamic_assessment" {
@@ -30,7 +44,7 @@ data "terraform_remote_state" "dynamic_assessment" {
     key            = "cool-accounts/dynamic.tfstate"
   }
 
-  workspace = var.assessment_account_name
+  workspace = local.workspace_name
 }
 
 data "terraform_remote_state" "images" {
@@ -45,7 +59,7 @@ data "terraform_remote_state" "images" {
     key            = "cool-accounts/images.tfstate"
   }
 
-  workspace = terraform.workspace
+  workspace = local.workspace_type
 }
 
 data "terraform_remote_state" "images_parameterstore" {
@@ -60,7 +74,7 @@ data "terraform_remote_state" "images_parameterstore" {
     key            = "cool-images-parameterstore/terraform.tfstate"
   }
 
-  workspace = terraform.workspace
+  workspace = local.workspace_type
 }
 
 data "terraform_remote_state" "master" {
@@ -75,7 +89,7 @@ data "terraform_remote_state" "master" {
     key            = "cool-accounts/master.tfstate"
   }
 
-  workspace = terraform.workspace
+  workspace = local.workspace_type
 }
 
 data "terraform_remote_state" "sharedservices" {
@@ -90,7 +104,7 @@ data "terraform_remote_state" "sharedservices" {
     key            = "cool-accounts/shared_services.tfstate"
   }
 
-  workspace = terraform.workspace
+  workspace = local.workspace_type
 }
 
 data "terraform_remote_state" "sharedservices_networking" {
@@ -105,5 +119,5 @@ data "terraform_remote_state" "sharedservices_networking" {
     key            = "cool-sharedservices-networking/terraform.tfstate"
   }
 
-  workspace = terraform.workspace
+  workspace = local.workspace_type
 }


### PR DESCRIPTION
## 🗣 Description

The workspace name in remote state configurations was previously hardcoded to "production".  This PR changes the code to instead use `terraform.workspace`, so that the workspace name changes as we switch between the production and staging environments.

## 💭 Motivation and Context

We need to be able to switch as seamlessly as possible between the production and staging environments.  The more manual foo that is required the more likely that we make a mistake and damage production.

## 🧪 Testing

These changes were successfully deployed to staging.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
