### PR TITLE
Automate Guacamole connections to all Kali instances

### DIFF
--- a/cloud-init/render-guac-connection-sql-template.py
+++ b/cloud-init/render-guac-connection-sql-template.py
@@ -13,11 +13,14 @@ import os
 import boto3
 import pystache
 
+INSTANCE_HOSTNAMES = "${instance_hostnames}".split(",")
 SQL_TEMPLATE = "${sql_template_fullpath}"
 # NOTE: Postgres processes initialization files alphabetically, so it's
 # important to name this file so it runs after the file that defines the
 # Guacamole tables and users ("00_initdb.sql").
-SQL_OUTPUT_FILE = "${guac_connection_setup_path}/${guac_connection_setup_filename}"
+SQL_OUTPUT_FILE_PREFIX = (
+    "${guac_connection_setup_path}/${guac_connection_setup_filename}"
+)
 
 # Inputs from terraform
 SSM_READ_ROLE_ARN = "${ssm_vnc_read_role_arn}"
@@ -47,21 +50,25 @@ ssm = boto3.client(
     aws_session_token=newsession_token,
 )
 
+data_for_pystache = dict()
 # Fetch the required parameters from SSM
-ssm_data = dict()
 for ssm_key, param_name in (
     (SSM_KEY_VNC_USER, "vnc_username"),
     (SSM_KEY_VNC_PASSWORD, "vnc_password"),
     (SSM_KEY_VNC_USER_PRIVATE_SSH_KEY, "vnc_user_private_ssh_key"),
 ):
     ssm_parameter = ssm.get_parameter(Name=ssm_key, WithDecryption=True)["Parameter"]
-    ssm_data[param_name] = ssm_parameter["Value"]
+    data_for_pystache[param_name] = ssm_parameter["Value"]
 
 # Ensure output (postgres initialization) directory is present before we put
 # our sql file there
 os.makedirs("${guac_connection_setup_path}", exist_ok=True)
 
-# Render template with SSM data and write output file
-with open(SQL_TEMPLATE) as infile:
-    with open(SQL_OUTPUT_FILE, "w") as outfile:
-        outfile.write(pystache.render(infile.read(), ssm_data))
+# Render template with SSM and hostname data,
+# then write output file for each host
+for host in INSTANCE_HOSTNAMES:
+    data_for_pystache["instance_hostname"] = host
+    sql_output_file = f"{SQL_OUTPUT_FILE_PREFIX}_{host}.sql"
+    with open(SQL_TEMPLATE) as infile:
+        with open(sql_output_file, "w") as outfile:
+            outfile.write(pystache.render(infile.read(), data_for_pystache))

--- a/cloud-init/write-guac-connection-sql-template.tpl.yml
+++ b/cloud-init/write-guac-connection-sql-template.tpl.yml
@@ -11,14 +11,14 @@ write_files:
     owner: root:root
     content: |
       --
-      -- Create connection for ${instance_hostname} instance
+      -- Create connection for {{ instance_hostname }} instance
       --
 
       INSERT INTO guacamole_connection (
         connection_name, protocol, max_connections, max_connections_per_user,
         proxy_port, proxy_hostname, proxy_encryption_method)
       VALUES (
-        '${instance_hostname}', 'vnc', 10, 10, 4822,
+        '{{ instance_hostname }}', 'vnc', 10, 10, 4822,
         'guacd', 'NONE');
 
       --
@@ -29,45 +29,45 @@ write_files:
         connection_id, parameter_name, parameter_value)
       SELECT connection_id, 'cursor', 'local'
       FROM guacamole_connection
-      WHERE connection_name = '${instance_hostname}'
+      WHERE connection_name = '{{ instance_hostname }}'
         UNION ALL
       SELECT
         connection_id, 'sftp-directory', '/home/{{ vnc_username }}/Documents'
       FROM guacamole_connection
-      WHERE connection_name = '${instance_hostname}'
+      WHERE connection_name = '{{ instance_hostname }}'
         UNION ALL
       SELECT connection_id, 'sftp-username', '{{ vnc_username }}'
       FROM guacamole_connection
-      WHERE connection_name = '${instance_hostname}'
+      WHERE connection_name = '{{ instance_hostname }}'
         UNION ALL
       SELECT connection_id, 'sftp-private-key', '{{ vnc_user_private_ssh_key }}'
       FROM guacamole_connection
-      WHERE connection_name = '${instance_hostname}'
+      WHERE connection_name = '{{ instance_hostname }}'
         UNION ALL
       SELECT connection_id, 'sftp-server-alive-interval', '60'
       FROM guacamole_connection
-      WHERE connection_name = '${instance_hostname}'
+      WHERE connection_name = '{{ instance_hostname }}'
         UNION ALL
       SELECT connection_id, 'sftp-root-directory', '/home/{{ vnc_username }}/'
       FROM guacamole_connection
-      WHERE connection_name = '${instance_hostname}'
+      WHERE connection_name = '{{ instance_hostname }}'
         UNION ALL
       SELECT connection_id, 'enable-sftp', 'true'
       FROM guacamole_connection
-      WHERE connection_name = '${instance_hostname}'
+      WHERE connection_name = '{{ instance_hostname }}'
         UNION ALL
       SELECT connection_id, 'color-depth', '24'
       FROM guacamole_connection
-      WHERE connection_name = '${instance_hostname}'
+      WHERE connection_name = '{{ instance_hostname }}'
         UNION ALL
-      SELECT connection_id, 'hostname', '${instance_hostname}.${private_domain}'
+      SELECT connection_id, 'hostname', '{{ instance_hostname }}'
       FROM guacamole_connection
-      WHERE connection_name = '${instance_hostname}'
+      WHERE connection_name = '{{ instance_hostname }}'
         UNION ALL
       SELECT connection_id, 'password', '{{ vnc_password }}'
       FROM guacamole_connection
-      WHERE connection_name = '${instance_hostname}'
+      WHERE connection_name = '{{ instance_hostname }}'
         UNION ALL
       SELECT connection_id, 'port', '5901'
       FROM guacamole_connection
-      WHERE connection_name = '${instance_hostname}';
+      WHERE connection_name = '{{ instance_hostname }}';

--- a/guacamole_cloud_init.tf
+++ b/guacamole_cloud_init.tf
@@ -20,7 +20,6 @@ data "template_cloudinit_config" "guacamole_cloud_init_tasks" {
     })
   }
 
-  # TODO: Make this more generalized and able to support a variety of connections
   # Set up Guacamole connection to Kali instance
   part {
     filename     = "write-kali-guac-connection-sql-template.yml"
@@ -31,7 +30,6 @@ data "template_cloudinit_config" "guacamole_cloud_init_tasks" {
     })
   }
 
-  # TODO: Make this more generalized and able to support a variety of connections
   # Set up Guacamole connection to Kali instance
   # NOTE: Postgres processes initialization files alphabetically, so it's
   # important to name guac_connection_setup_filename so it runs after the

--- a/guacamole_cloud_init.tf
+++ b/guacamole_cloud_init.tf
@@ -34,6 +34,10 @@ data "template_cloudinit_config" "guacamole_cloud_init_tasks" {
   # NOTE: Postgres processes initialization files alphabetically, so it's
   # important to name guac_connection_setup_filename so it runs after the
   # file that defines the Guacamole tables and users ("00_initdb.sql").
+  # NOTE: Terraform's templatefile() function complains when I pass in a
+  # list input, so I convert the list of instance hostnames below to a
+  # comma-separated list of strings.  I tried to find a way to avoid
+  # doing this, but was unsuccessful.
   part {
     filename     = "render-kali-guac-connection-sql-template.py"
     content_type = "text/x-shellscript"

--- a/guacamole_cloud_init.tf
+++ b/guacamole_cloud_init.tf
@@ -27,8 +27,6 @@ data "template_cloudinit_config" "guacamole_cloud_init_tasks" {
     content_type = "text/cloud-config"
     content = templatefile(
       "${path.module}/cloud-init/write-guac-connection-sql-template.tpl.yml", {
-        instance_hostname     = "kali0"
-        private_domain        = var.private_domain
         sql_template_fullpath = "/root/kali_guacamole_connection_template.sql"
     })
   }
@@ -44,8 +42,9 @@ data "template_cloudinit_config" "guacamole_cloud_init_tasks" {
     content = templatefile(
       "${path.module}/cloud-init/render-guac-connection-sql-template.py", {
         aws_region                       = var.aws_region
-        guac_connection_setup_filename   = "01_setup_kali_guac_connection.sql"
+        guac_connection_setup_filename   = "01_setup_guac_connections"
         guac_connection_setup_path       = var.guac_connection_setup_path
+        instance_hostnames               = join(",", aws_route53_record.kali_A[*].name)
         ssm_vnc_read_role_arn            = aws_iam_role.vnc_parameterstorereadonly_role.arn
         ssm_key_vnc_password             = var.ssm_key_vnc_password
         ssm_key_vnc_user                 = var.ssm_key_vnc_username


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description

<!--- Describe your changes in detail -->
Currently, when the Guacamole instance is deployed, two `cloud-init` scripts are used to automate the process of creating a connection (within Guacamole) to a single Kali instance (`kali0`).  Since we recently made it possible to deploy multiple Kali instances (see #16), this PR automates the process of creating Guacamole connections for every Kali instance in the environment (not just the first one).

Resolves #19.

## 💭 Motivation and Context
The previous approach (a single hard-coded Guacamole connection) was always meant to be temporary.  This is a more complete solution.

Previously, a single SQL file was created (to be processed by Postgres at container startup): `01_setup_kali_guac_connection.sql`

This PR makes it so that one SQL file is created for each Kali instance:
- `01_setup_kali_guac_connection_kali0.env1.sql`
- `01_setup_kali_guac_connection_kali1.env1.sql`
- ...

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
These changes were applied in `env1` and the Guacamole connections to each Kali instance were successfully created automatically. 

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
