### PR TITLE
Remove ephemeral ingress declarations from security groups

### DIFF
--- a/desktop_gateway_sg_rules.tf
+++ b/desktop_gateway_sg_rules.tf
@@ -66,16 +66,3 @@ resource "aws_security_group_rule" "desktop_gw_egress_to_ops_via_vnc" {
   from_port         = 5901
   to_port           = 5901
 }
-
-# Allow ingress from anywhere via ephemeral ports
-# For: Guacamole fetches its SSL certificate via boto3 (which uses HTTPS)
-resource "aws_security_group_rule" "desktop_gw_ingress_from_anywhere_via_ephemeral_ports" {
-  provider = aws.provisionassessment
-
-  security_group_id = aws_security_group.desktop_gateway.id
-  type              = "ingress"
-  protocol          = "tcp"
-  cidr_blocks       = ["0.0.0.0/0"]
-  from_port         = 1024
-  to_port           = 65535
-}

--- a/operations_sg_rules.tf
+++ b/operations_sg_rules.tf
@@ -39,51 +39,6 @@ resource "aws_security_group_rule" "operations_ingress_from_anywhere_via_allowed
   to_port           = each.value
 }
 
-# Allow ingress from anywhere via ephemeral TCP/UDP ports below 3389 (1024-3388)
-# For: Assessment team operational use, but don't want to allow
-#      public access to RDP on port 3389
-resource "aws_security_group_rule" "operations_ingress_from_anywhere_via_ports_1024_thru_3388" {
-  provider = aws.provisionassessment
-  for_each = toset(local.tcp_and_udp)
-
-  security_group_id = aws_security_group.operations.id
-  type              = "ingress"
-  protocol          = each.value
-  cidr_blocks       = ["0.0.0.0/0"]
-  from_port         = 1024
-  to_port           = 3388
-}
-
-# Allow ingress from anywhere via ephemeral TCP/UDP ports 3390-5900
-# For: Assessment team operational use, but don't want to allow
-#      public access to RDP on port 3389 or VNC on port 5901
-resource "aws_security_group_rule" "operations_ingress_from_anywhere_via_ports_3390_thru_5900" {
-  provider = aws.provisionassessment
-  for_each = toset(local.tcp_and_udp)
-
-  security_group_id = aws_security_group.operations.id
-  type              = "ingress"
-  protocol          = each.value
-  cidr_blocks       = ["0.0.0.0/0"]
-  from_port         = 3390
-  to_port           = 5900
-}
-
-# Allow ingress from anywhere via ephemeral TCP/UDP ports above 5901 (5902-65535)
-# For: Assessment team operational use, but don't want to allow
-#      public access to VNC on port 5901
-resource "aws_security_group_rule" "operations_ingress_from_anywhere_via_ports_5902_thru_65535" {
-  provider = aws.provisionassessment
-  for_each = toset(local.tcp_and_udp)
-
-  security_group_id = aws_security_group.operations.id
-  type              = "ingress"
-  protocol          = each.value
-  cidr_blocks       = ["0.0.0.0/0"]
-  from_port         = 5902
-  to_port           = 65535
-}
-
 # Allow ingress from anywhere via ICMP
 # For: Assessment team operational use (e.g. ping responses)
 resource "aws_security_group_rule" "operations_ingress_from_anywhere_via_icmp" {


### PR DESCRIPTION
## 🗣 Description

In this pull request I remove the security group rules related to ephemeral ports.

## 💭 Motivation and Context

Security groups are effectively stateful firewalls, and thus do not require ephemeral port ingress to be declared.  See, for example, the sixth bullet listed [here](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_SecurityGroups.html#VPCSecurityGroups).  In fact, opening these ports needlessly is a very bad idea.

This also related to our discussion with Bob [here](https://chat.google.com/room/AAAA3CGdCO4/2AK-pvmAxoI).

## 🧪 Testing

All pre-commit hooks pass.  I verified that I can still get into env0-staging and env1-staging via Guacamole after applying these changes.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
