### PR TITLE
Use beefier instances for Guacamole and Kali

### DIFF
--- a/guacamole_ec2.tf
+++ b/guacamole_ec2.tf
@@ -30,7 +30,7 @@ resource "aws_instance" "guacamole" {
   ami                  = data.aws_ami.guacamole.id
   availability_zone    = "${var.aws_region}${var.aws_availability_zone}"
   iam_instance_profile = aws_iam_instance_profile.guacamole.name
-  instance_type        = "t3.micro"
+  instance_type        = "t3.medium"
   subnet_id            = aws_subnet.private[var.private_subnet_cidr_blocks[0]].id
 
   root_block_device {

--- a/kali_ec2.tf
+++ b/kali_ec2.tf
@@ -48,6 +48,6 @@ resource "aws_instance" "kali" {
     aws_security_group.operations.id,
   ]
 
-  tags        = merge(var.tags, map("Name", "Kali"))
-  volume_tags = merge(var.tags, map("Name", "Kali"))
+  tags        = merge(var.tags, map("Name", format("Kali%d", count.index)))
+  volume_tags = merge(var.tags, map("Name", format("Kali%d", count.index)))
 }

--- a/kali_ec2.tf
+++ b/kali_ec2.tf
@@ -32,7 +32,7 @@ resource "aws_instance" "kali" {
   associate_public_ip_address = true
   availability_zone           = "${var.aws_region}${var.aws_availability_zone}"
   iam_instance_profile        = aws_iam_instance_profile.kali.name
-  instance_type               = "t2.medium"
+  instance_type               = "t2.large"
   subnet_id                   = aws_subnet.operations.id
 
   root_block_device {


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR does the following:
- Increases the Guacamole instance type from a `t3.micro` to a `t3.medium`
- Increases the Kali instance type from a `t2.medium` to a `t2.large`
- Appends the Kali instance count number to the AWS `Name` tag

Resolves #27.
<!--- Describe your changes in detail -->

## 💭 Motivation and Context
For the instance type increases, we were seeing some memory issues in our testing environments (e.g. #27), so let's throw some RAM at the problem and see what happens.

For the `Name` tag change, this makes it much easier to locate the correct Kali instance in the AWS console.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
I applied these changes in `env0-staging` and `env1-staging` and verified that everything looked as it should.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
