### PR TITLE
Correctly handle undefined instance counts

### DIFF
--- a/kali_ec2.tf
+++ b/kali_ec2.tf
@@ -25,7 +25,7 @@ data "aws_ami" "kali" {
 
 # The Kali EC2 instance
 resource "aws_instance" "kali" {
-  count    = var.operations_instance_counts["kali"]
+  count    = lookup(var.operations_instance_counts, "kali", 0)
   provider = aws.provisionassessment
 
   ami                         = data.aws_ami.kali.id

--- a/kali_route53.tf
+++ b/kali_route53.tf
@@ -1,6 +1,6 @@
 # Private DNS A record for Kali instance
 resource "aws_route53_record" "kali_A" {
-  count    = var.operations_instance_counts["kali"]
+  count    = lookup(var.operations_instance_counts, "kali", 0)
   provider = aws.provisionassessment
 
   zone_id = aws_route53_zone.assessment_private.zone_id

--- a/nessus_cloud_init.tf
+++ b/nessus_cloud_init.tf
@@ -1,7 +1,7 @@
 # cloud-init commands for configuring Nessus instances
 
 data "template_cloudinit_config" "nessus_cloud_init_tasks" {
-  count = var.operations_instance_counts["nessus"]
+  count = lookup(var.operations_instance_counts, "nessus", 0)
 
   gzip          = true
   base64_encode = true

--- a/nessus_ec2.tf
+++ b/nessus_ec2.tf
@@ -25,7 +25,7 @@ data "aws_ami" "nessus" {
 
 # The Nessus EC2 instance
 resource "aws_instance" "nessus" {
-  count    = var.operations_instance_counts["nessus"]
+  count    = lookup(var.operations_instance_counts, "nessus", 0)
   provider = aws.provisionassessment
 
   ami                         = data.aws_ami.nessus.id

--- a/nessus_route53.tf
+++ b/nessus_route53.tf
@@ -1,6 +1,6 @@
 # Private DNS A record for Nessus instance
 resource "aws_route53_record" "nessus_A" {
-  count    = var.operations_instance_counts["nessus"]
+  count    = lookup(var.operations_instance_counts, "nessus", 0)
   provider = aws.provisionassessment
 
   zone_id = aws_route53_zone.assessment_private.zone_id


### PR DESCRIPTION

# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR changes the way we lookup the number of defined instances so that if an instance type (e.g. `kali` or `nessus`) is not listed in the `operations_instance_counts` dictionary, the number of instances for that type defaults to zero.

<!--- Describe your changes in detail -->

## 💭 Motivation and Context
@felddy expected this behavior while deploying to an environment with no defined Nessus instances but instead, he got a Terraform error:
```
Error: Invalid index

  on nessus_cloud_init.tf line 4, in data "template_cloudinit_config" "nessus_cloud_init_tasks":
   4:   count = var.operations_instance_counts["nessus"]
    |----------------
    | var.operations_instance_counts is map of number with 1 element

The given key does not identify an element in this collection value.
```
This PR remedies that situation.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
I ran `terraform plan` with no defined `kali` or `nessus` instances in the `operations_instance_counts` dictionary and no errors were observed.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
