### PR TITLE
Only create Nessus-related resources when necessary

### DIFF
--- a/nessus_assume_role_policy_doc.tf
+++ b/nessus_assume_role_policy_doc.tf
@@ -4,6 +4,8 @@
 # ------------------------------------------------------------------------------
 
 data "aws_iam_policy_document" "nessus_assume_role_doc" {
+  count = lookup(var.operations_instance_counts, "nessus", 0) > 0 ? 1 : 0
+
   statement {
     actions = [
       "sts:AssumeRole",
@@ -12,7 +14,7 @@ data "aws_iam_policy_document" "nessus_assume_role_doc" {
     principals {
       type = "AWS"
       identifiers = [
-        aws_iam_role.nessus_instance_role.arn
+        aws_iam_role.nessus_instance_role[count.index].arn
       ]
     }
   }

--- a/nessus_cloud_init.tf
+++ b/nessus_cloud_init.tf
@@ -20,7 +20,7 @@ data "template_cloudinit_config" "nessus_cloud_init_tasks" {
         nessus_activation_code        = var.nessus_activation_codes[count.index]
         ssm_key_nessus_admin_password = var.ssm_key_nessus_admin_password
         ssm_key_nessus_admin_username = var.ssm_key_nessus_admin_username
-        ssm_nessus_read_role_arn      = aws_iam_role.nessus_parameterstorereadonly_role.arn
+        ssm_nessus_read_role_arn      = aws_iam_role.nessus_parameterstorereadonly_role[0].arn
     })
   }
 }

--- a/nessus_ec2.tf
+++ b/nessus_ec2.tf
@@ -36,7 +36,7 @@ resource "aws_instance" "nessus" {
   ami                         = data.aws_ami.nessus.id
   associate_public_ip_address = true
   availability_zone           = "${var.aws_region}${var.aws_availability_zone}"
-  iam_instance_profile        = aws_iam_instance_profile.nessus.name
+  iam_instance_profile        = aws_iam_instance_profile.nessus[0].name
   instance_type               = "m5.large"
   subnet_id                   = aws_subnet.operations.id
 

--- a/nessus_iam.tf
+++ b/nessus_iam.tf
@@ -2,14 +2,16 @@
 
 # The instance profile to be used
 resource "aws_iam_instance_profile" "nessus" {
+  count    = lookup(var.operations_instance_counts, "nessus", 0) > 0 ? 1 : 0
   provider = aws.provisionassessment
 
   name = "nessus_instance_profile_${terraform.workspace}"
-  role = aws_iam_role.nessus_instance_role.name
+  role = aws_iam_role.nessus_instance_role[count.index].name
 }
 
 # The instance role
 resource "aws_iam_role" "nessus_instance_role" {
+  count    = lookup(var.operations_instance_counts, "nessus", 0) > 0 ? 1 : 0
   provider = aws.provisionassessment
 
   name               = "nessus_instance_role_${terraform.workspace}"
@@ -17,18 +19,20 @@ resource "aws_iam_role" "nessus_instance_role" {
 }
 
 resource "aws_iam_role_policy" "nessus_assume_delegated_role_policy" {
+  count    = lookup(var.operations_instance_counts, "nessus", 0) > 0 ? 1 : 0
   provider = aws.provisionassessment
 
   name   = "nessus_assume_delegated_role_policy"
-  role   = aws_iam_role.nessus_instance_role.id
-  policy = data.aws_iam_policy_document.nessus_assume_delegated_role_policy_doc.json
+  role   = aws_iam_role.nessus_instance_role[count.index].id
+  policy = data.aws_iam_policy_document.nessus_assume_delegated_role_policy_doc[count.index].json
 }
 
 # Attach the CloudWatch Agent policy to this role as well
 resource "aws_iam_role_policy_attachment" "cloudwatch_agent_policy_attachment_nessus" {
+  count    = lookup(var.operations_instance_counts, "nessus", 0) > 0 ? 1 : 0
   provider = aws.provisionassessment
 
-  role       = aws_iam_role.nessus_instance_role.id
+  role       = aws_iam_role.nessus_instance_role[count.index].id
   policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
 }
 
@@ -50,10 +54,12 @@ data "aws_iam_policy_document" "nessus_assume_role_policy_doc" {
 # Allow the Nessus instance to assume the role needed
 # to read the Nessus-related data from the SSM Parameter Store
 data "aws_iam_policy_document" "nessus_assume_delegated_role_policy_doc" {
+  count = lookup(var.operations_instance_counts, "nessus", 0) > 0 ? 1 : 0
+
   statement {
     actions = ["sts:AssumeRole"]
     resources = [
-      aws_iam_role.nessus_parameterstorereadonly_role.arn
+      aws_iam_role.nessus_parameterstorereadonly_role[count.index].arn
     ]
     effect = "Allow"
   }

--- a/nessus_parameterstorereadonly_policy.tf
+++ b/nessus_parameterstorereadonly_policy.tf
@@ -17,6 +17,7 @@ data "aws_iam_policy_document" "nessus_parameterstorereadonly_doc" {
 }
 
 resource "aws_iam_policy" "nessus_parameterstorereadonly_policy" {
+  count    = lookup(var.operations_instance_counts, "nessus", 0) > 0 ? 1 : 0
   provider = aws.provisionparameterstorereadrole
 
   description = local.nessus_parameterstorereadonly_role_description

--- a/nessus_parameterstorereadonly_role.tf
+++ b/nessus_parameterstorereadonly_role.tf
@@ -4,17 +4,19 @@
 # ------------------------------------------------------------------------------
 
 resource "aws_iam_role" "nessus_parameterstorereadonly_role" {
+  count    = lookup(var.operations_instance_counts, "nessus", 0) > 0 ? 1 : 0
   provider = aws.provisionparameterstorereadrole
 
-  assume_role_policy = data.aws_iam_policy_document.nessus_assume_role_doc.json
+  assume_role_policy = data.aws_iam_policy_document.nessus_assume_role_doc[count.index].json
   description        = local.nessus_parameterstorereadonly_role_description
   name               = local.nessus_parameterstorereadonly_role_name
   tags               = var.tags
 }
 
 resource "aws_iam_role_policy_attachment" "nessus_parameterstorereadonly_policy_attachment" {
+  count    = lookup(var.operations_instance_counts, "nessus", 0) > 0 ? 1 : 0
   provider = aws.provisionparameterstorereadrole
 
-  policy_arn = aws_iam_policy.nessus_parameterstorereadonly_policy.arn
-  role       = aws_iam_role.nessus_parameterstorereadonly_role.name
+  policy_arn = aws_iam_policy.nessus_parameterstorereadonly_policy[count.index].arn
+  role       = aws_iam_role.nessus_parameterstorereadonly_role[count.index].name
 }

--- a/operations_sg_rules.tf
+++ b/operations_sg_rules.tf
@@ -27,6 +27,7 @@ resource "aws_security_group_rule" "operations_ingress_from_guacamole_via_vnc" {
 # Allow ingress from Kali instances via Nessus web GUI
 # For: Assessment team Nessus web access from Kali instances
 resource "aws_security_group_rule" "operations_ingress_from_kali_for_nessus" {
+  count    = lookup(var.operations_instance_counts, "nessus", 0) > 0 ? 1 : 0
   provider = aws.provisionassessment
 
   security_group_id = aws_security_group.operations.id


### PR DESCRIPTION


# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR modifies many Nessus-related resources and data so that they are only created if one (or more) Nessus instances are defined in `var.operations_instance_counts`.

<!--- Describe your changes in detail -->

## 💭 Motivation and Context
If there are no Nessus instances in the environment, there's no need to create any Nessus-related resources.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
These changes were tested and applied in the `env1-production` environment.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
