### PR TITLE
Remove teamserver from the EFS client security group

### DIFF
--- a/teamserver_ec2.tf
+++ b/teamserver_ec2.tf
@@ -42,7 +42,6 @@ resource "aws_instance" "teamserver" {
   }
 
   vpc_security_group_ids = [
-    aws_security_group.efs_client.id,
     aws_security_group.operations.id,
   ]
 


### PR DESCRIPTION
## 🗣 Description

This pull request removes the teamserver(s) from the EFS client security group.  Teamservers should not be in that security group, since they do not need to mount the EFS share.

Somehow I neglected to remove this in #33.  Thanks to @dav3r for pointing this out!

## 💭 Motivation and Context

Correcting this tightens network security for the teamservers and the EFS share.

## 🧪 Testing

None required.
![image](https://user-images.githubusercontent.com/5521725/81761312-a0627100-9497-11ea-91cd-66984e10c229.png)

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
