### PR TITLE
Allow Operations subnet ingress on port 993 from Kali instances

### DIFF
--- a/operations_sg_rules.tf
+++ b/operations_sg_rules.tf
@@ -24,6 +24,20 @@ resource "aws_security_group_rule" "operations_ingress_from_guacamole_via_vnc" {
   to_port           = 5901
 }
 
+# Allow ingress from Kali instances via port 993 (IMAP over TLS/SSL)
+# For: Assessment team IMAP access on Teamservers from Kali instances
+resource "aws_security_group_rule" "operations_ingress_from_kali_via_imaps" {
+  count    = lookup(var.operations_instance_counts, "teamserver", 0) > 0 ? 1 : 0
+  provider = aws.provisionassessment
+
+  security_group_id = aws_security_group.operations.id
+  type              = "ingress"
+  protocol          = "tcp"
+  cidr_blocks       = formatlist("%s/32", aws_instance.kali[*].private_ip)
+  from_port         = 993
+  to_port           = 993
+}
+
 # Allow ingress from Kali instances via Nessus web GUI
 # For: Assessment team Nessus web access from Kali instances
 resource "aws_security_group_rule" "operations_ingress_from_kali_for_nessus" {


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR allows ingress to the Operations subnet from Kali instances via port 993 (IMAP over TLS/SSL).

<!--- Describe your changes in detail -->

## 💭 Motivation and Context
This is a requirement for the PCA team- as part of their operations, they use an email client on the Kali instance to talk to the Teamserver via secure IMAP.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
All automated tests pass and this change was successfully applied and verified in `env1-production`.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
