### PR TITLE
Elastic IPs and EFS for Teamservers

### DIFF
--- a/provisionassessment_policy.tf
+++ b/provisionassessment_policy.tf
@@ -7,6 +7,7 @@ data "aws_iam_policy_document" "provisionassessment_policy_doc" {
   statement {
     actions = [
       "ec2:AllocateAddress",
+      "ec2:AssociateAddress",
       "ec2:AssociateDhcpOptions",
       "ec2:AssociateRouteTable",
       "ec2:AssociateTransitGatewayRouteTable",
@@ -41,6 +42,7 @@ data "aws_iam_policy_document" "provisionassessment_policy_doc" {
       "ec2:DeleteVpc",
       "ec2:Describe*",
       "ec2:DetachInternetGateway",
+      "ec2:DisassociateAddress",
       "ec2:DisassociateRouteTable",
       "ec2:DisassociateTransitGatewayRouteTable",
       "ec2:DisassociateVpcCidrBlock",

--- a/teamserver_ec2.tf
+++ b/teamserver_ec2.tf
@@ -41,7 +41,12 @@ resource "aws_instance" "teamserver" {
     delete_on_termination = true
   }
 
+  # We can use the same cloud-init code as the Kali instances, since
+  # all it does is set up /etc/fstab to mount the EFS file share.
+  user_data_base64 = data.template_cloudinit_config.kali_cloud_init_tasks.rendered
+
   vpc_security_group_ids = [
+    aws_security_group.efs_client.id,
     aws_security_group.operations.id,
   ]
 

--- a/teamserver_iam.tf
+++ b/teamserver_iam.tf
@@ -26,3 +26,14 @@ resource "aws_iam_role_policy_attachment" "cloudwatch_agent_policy_attachment_te
   role       = aws_iam_role.teamserver_instance_role.id
   policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
 }
+
+# Attach a policy that allows the Teamserver instances to mount and
+# write to the EFS
+resource "aws_iam_role_policy_attachment" "efs_mount_policy_attachment_teamserver" {
+  provider = aws.provisionassessment
+
+  role = aws_iam_role.teamserver_instance_role.id
+  # We can just reuse the kali policy here.  If we created a
+  # teamserver-specific one it would be identical.
+  policy_arn = aws_iam_policy.kali_efs_mount_policy.arn
+}


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR does the following:
- Adds a persistent elastic IP to each Teamserver
- Mounts the EFS file share on each Teamserver

As requested in https://github.com/cisagov/cool-assessment-terraform/issues/40.

<!--- Describe your changes in detail -->

## 💭 Motivation and Context
Assessment teams require persistent IPs and persistent data storage for the Teamservers.

The EFS access for Teamservers was previously added (https://github.com/cisagov/cool-assessment-terraform/pull/33/commits/c70ae0fc956decd18d7acc9661fd4d7861217975), then removed (https://github.com/cisagov/cool-assessment-terraform/pull/33/commits/3f228fa20e473f1c883be2d79a2ccc3a2d323b5b, https://github.com/cisagov/cool-assessment-terraform/pull/37/commits/719da96057d95f8d8c300f12dbb6bdd9d62471f2) because it was not required for RPT assessments.  However, since it is necessary for PCA, it is being re-added.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
These changes were applied and successfully verified in `env1-staging`.
All automated tests pass.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
