### PR TITLE
Automatically define Guacamole connections for all Operations instances

### DIFF
--- a/guacamole_cloud_init.tf
+++ b/guacamole_cloud_init.tf
@@ -20,38 +20,42 @@ data "template_cloudinit_config" "guacamole_cloud_init_tasks" {
     })
   }
 
-  # Set up Guacamole connection to Kali instance
+  # Set up Guacamole connection(s) to operations instance(s)
   part {
-    filename     = "write-kali-guac-connection-sql-template.yml"
+    filename     = "write-guac-connection-sql-template.yml"
     content_type = "text/cloud-config"
     content = templatefile(
       "${path.module}/cloud-init/write-guac-connection-sql-template.tpl.yml", {
-        sql_template_fullpath = "/root/kali_guacamole_connection_template.sql"
+        sql_template_fullpath = "/root/guacamole_connection_template.sql"
     })
   }
 
-  # Set up Guacamole connection to Kali instance
-  # NOTE: Postgres processes initialization files alphabetically, so it's
+  # Set up Guacamole connection(s) to operations instance(s)
+  # NOTES:
+  # - Postgres processes initialization files alphabetically, so it's
   # important to name guac_connection_setup_filename so it runs after the
   # file that defines the Guacamole tables and users ("00_initdb.sql").
   # NOTE: Terraform's templatefile() function complains when I pass in a
   # list input, so I convert the list of instance hostnames below to a
   # comma-separated list of strings.  I tried to find a way to avoid
   # doing this, but was unsuccessful.
+  # - When new types of operations instance are added, they should be
+  # included in the list of "instance_hostnames" below so that their
+  # Guacamole connections are automatically created.
   part {
-    filename     = "render-kali-guac-connection-sql-template.py"
+    filename     = "render-guac-connection-sql-template.py"
     content_type = "text/x-shellscript"
     content = templatefile(
       "${path.module}/cloud-init/render-guac-connection-sql-template.py", {
         aws_region                       = var.aws_region
         guac_connection_setup_filename   = "01_setup_guac_connections"
         guac_connection_setup_path       = var.guac_connection_setup_path
-        instance_hostnames               = join(",", aws_route53_record.kali_A[*].name)
+        instance_hostnames               = join(",", concat(aws_route53_record.gophish_A[*].name, aws_route53_record.kali_A[*].name, aws_route53_record.teamserver_A[*].name))
         ssm_vnc_read_role_arn            = aws_iam_role.vnc_parameterstorereadonly_role.arn
         ssm_key_vnc_password             = var.ssm_key_vnc_password
         ssm_key_vnc_user                 = var.ssm_key_vnc_username
         ssm_key_vnc_user_private_ssh_key = var.ssm_key_vnc_user_private_ssh_key
-        sql_template_fullpath            = "/root/kali_guacamole_connection_template.sql"
+        sql_template_fullpath            = "/root/guacamole_connection_template.sql"
     })
   }
 }


### PR DESCRIPTION


# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR updates the Guacamole cloud-init script so that it automatically defines Guacamole connections for all Operations instance types in the environment (GoPhish, Kali, Teamserver).

<!--- Describe your changes in detail -->

## 💭 Motivation and Context
Previously, only connections for Kali instance types were created by this cloud-init script.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
All automated tests pass.  These changes were successfully tested in `env1-staging`.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
