### PR TITLE
Enroll Guacamole instance in FreeIPA domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ the COOL environment.
 | aws_region | The AWS region to deploy into (e.g. us-east-1). | string | `us-east-1` | no |
 | cert_bucket_name | The name of the AWS S3 bucket where certificates are stored. | string | `cisa-cool-certificates` | no |
 | cool_domain | The domain where the COOL resources reside (e.g. "cool.cyber.dhs.gov"). | string | `cool.cyber.dhs.gov` | no |
+| freeipa_admin_pw | The password for the Kerberos admin role, which is required for the Guacamole instance to join the FreeIPA domain. | string | | yes |
 | guac_connection_setup_path | The full path to the dbinit directory where initialization files must be stored in order to work properly (e.g. "/var/guacamole/dbinit"). | string | `/var/guacamole/dbinit` | no |
 | nessus_activation_codes | The list of Nessus activation codes (e.g. ["AAAA-BBBB-CCCC-DDDD"]). The number of codes in this list should match the number of Nessus instances defined in operations_instance_counts. | list(string) | `[]` | no |
 | operations_instance_counts | A map specifying how many instances of each type should be created in the operations subnet (e.g. { "kali": 1 }).  The currently-supported instance keys are: ["gophish", "kali", "nessus", "teamserver"]. | map(number) | `{ "kali": 1 }` | no |

--- a/cloud-init/freeipa-creds.tpl.yml
+++ b/cloud-init/freeipa-creds.tpl.yml
@@ -1,0 +1,12 @@
+# cloud-config
+# vim: syntax=yaml
+---
+
+write_files:
+  - path: /var/lib/cloud/instance/freeipa-creds.sh
+    permissions: '0400'
+    owner: root:root
+    content: |
+      ADMIN_PW=${admin_pw}
+      HOSTNAME=${hostname}
+      REALM=${realm}

--- a/desktop_gateway_sg_rules.tf
+++ b/desktop_gateway_sg_rules.tf
@@ -52,3 +52,17 @@ resource "aws_security_group_rule" "desktop_gw_egress_to_ops_via_vnc" {
   from_port         = 5901
   to_port           = 5901
 }
+
+# Allow egress to COOL Shared Services via IPA-related ports
+# For: Guacamole instance communication with FreeIPA
+resource "aws_security_group_rule" "desktop_gw_egress_to_cool_via_ipa_ports" {
+  provider = aws.provisionassessment
+  for_each = local.ipa_ports
+
+  security_group_id = aws_security_group.desktop_gateway.id
+  type              = "egress"
+  protocol          = each.value.proto
+  cidr_blocks       = [local.cool_shared_services_cidr_block]
+  from_port         = each.value.port
+  to_port           = each.value.port
+}

--- a/guacamole_route53.tf
+++ b/guacamole_route53.tf
@@ -7,3 +7,29 @@ resource "aws_route53_record" "guacamole_A" {
   ttl     = var.dns_ttl
   records = [aws_instance.guacamole.private_ip]
 }
+
+resource "aws_route53_record" "guacamole_PTR" {
+  provider = aws.provisionassessment
+
+  zone_id = aws_route53_zone.private_subnet_reverse[var.private_subnet_cidr_blocks[0]].id
+  # Terraform and/or AWS appends the reverse zone name if you specify
+  # just enough of the record name to "fill in" the rest of the PTR record.
+  # For example, if this record were for the IP 10.11.12.13, going into the
+  # reverse zone with name "12.11.10.in-addr-arpa.", then you could provide
+  # the entire record name ("13.12.11.10.in-addr.arpa.") or just the last
+  # octet ("13").  If you do the latter, then look at the corresponding
+  # Route53 record in the AWS console, you can see that the
+  # ".12.11.10.in-addr.arpa." part of the name has been automatically added.
+  #
+  # This allows us to create PTR records more succinctly.
+  name = format(
+    "%s",
+    element(split(".", aws_instance.guacamole.private_ip), 3)
+  )
+
+  type = "PTR"
+  ttl  = var.dns_ttl
+  records = [
+    "guac.${local.assessment_account_name_base}.${var.cool_domain}"
+  ]
+}

--- a/locals.tf
+++ b/locals.tf
@@ -99,6 +99,52 @@ locals {
   private_domain = var.private_domain != "" ? var.private_domain : local.assessment_account_name_base
 
   # Helpful lists for defining ACL and security group rules
+
+  # The ports used to communicate with IPA servers.  The "index" value is
+  # used as a counter in certain ACL rules.
+  ipa_ports = {
+    http = {
+      proto = "tcp",
+      port  = 80,
+      index = 1,
+    },
+    kinit_tcp = {
+      proto = "tcp",
+      port  = 88,
+      index = 2,
+    },
+    kinit_udp = {
+      proto = "udp",
+      port  = 88,
+      index = 3,
+    },
+    https = {
+      proto = "tcp",
+      port  = 443,
+      index = 4,
+    },
+    kpasswd_tcp = {
+      proto = "tcp",
+      port  = 464,
+      index = 5,
+    },
+    kpasswd_udp = {
+      proto = "udp",
+      port  = 464,
+      index = 6,
+    },
+    ldap = {
+      proto = "tcp",
+      port  = 389,
+      index = 7,
+    },
+    ldaps = {
+      proto = "tcp",
+      port  = 636,
+      index = 8,
+    }
+  }
+
   ingress_and_egress = [
     "ingress",
     "egress",

--- a/private_acl_rules.tf
+++ b/private_acl_rules.tf
@@ -145,3 +145,20 @@ resource "aws_network_acl_rule" "private_egress_to_operations_via_vnc" {
   from_port      = 5901
   to_port        = 5901
 }
+
+# Allow egress to COOL Shared Services via IPA-related ports
+# For: Guacamole instance communication with FreeIPA
+# Note that these rules only apply to the private subnet with Guacamole.
+resource "aws_network_acl_rule" "private_egress_to_cool_via_ipa_ports" {
+  provider = aws.provisionassessment
+  for_each = local.ipa_ports
+
+  network_acl_id = aws_network_acl.private[var.private_subnet_cidr_blocks[0]].id
+  egress         = true
+  protocol       = each.value.proto
+  rule_number    = 130 + each.value.index
+  rule_action    = "allow"
+  cidr_block     = local.cool_shared_services_cidr_block
+  from_port      = each.value.port
+  to_port        = each.value.port
+}

--- a/route53.tf
+++ b/route53.tf
@@ -16,3 +16,26 @@ resource "aws_route53_zone" "assessment_private" {
   )
   comment = "Terraform Workspace: ${terraform.workspace}"
 }
+
+
+# Private Route53 reverse zones for the private subnets
+resource "aws_route53_zone" "private_subnet_reverse" {
+  provider = aws.provisionassessment
+
+  for_each = toset(var.private_subnet_cidr_blocks)
+  lifecycle {
+    ignore_changes = [vpc]
+  }
+
+  # Note that this code assumes that we are using /24 blocks.
+  name = format(
+    "%s.%s.%s.in-addr.arpa.",
+    element(split(".", each.value), 2),
+    element(split(".", each.value), 1),
+    element(split(".", each.value), 0),
+  )
+  tags = var.tags
+  vpc {
+    vpc_id = aws_vpc.assessment.id
+  }
+}

--- a/transitgateway.tf
+++ b/transitgateway.tf
@@ -17,8 +17,10 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "assessment" {
 
   # All subnets of the VPC are currently in the same availability
   # zone, so it doesn't matter which subnet ID we use for the Transit
-  # Gateway attachment.
-  subnet_ids         = [aws_subnet.operations.id]
+  # Gateway attachment.  We chose to put it in the subnet containing the
+  # Guacamole instance in order to simplify the ACL rules for LDAP/Kerberos
+  # traffic between Guacamole and the Transit Gateway attachment.
+  subnet_ids         = [aws_subnet.private[var.private_subnet_cidr_blocks[0]].id]
   tags               = var.tags
   transit_gateway_id = local.transit_gateway_id
   vpc_id             = aws_vpc.assessment.id

--- a/variables.tf
+++ b/variables.tf
@@ -9,6 +9,11 @@ variable "assessment_account_name" {
   description = "The name of the AWS account for this assessment (e.g. \"env0\")."
 }
 
+variable "freeipa_admin_pw" {
+  type        = string
+  description = "The password for the Kerberos admin role, which is required for the Guacamole instance to join the FreeIPA domain."
+}
+
 variable "operations_subnet_cidr_block" {
   type        = string
   description = "The operations subnet CIDR block for this assessment (e.g. \"10.10.0.0/24\")."


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR makes the Guacamole instance enroll in the FreeIPA domain at startup.

<!--- Describe your changes in detail -->

## 💭 Motivation and Context
In order for us to make Guacamole work with Kerberos, we first must be able to get the Guacamole instance on the FreeIPA domain. This PR accomplishes that.

Resolves https://github.com/cisagov/cool-system/issues/50 (in conjunction with https://github.com/cisagov/guacamole-packer/pull/17).

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
These changes were successfully applied in `env0-staging` and I verified that the `freeipa-enroll` service ran successfully:
```
guac:~$ sudo systemctl status freeipa-enroll
● freeipa-enroll.service - Handle enrollment and unenrollment of FreeIPA clients
   Loaded: loaded (/lib/systemd/system/freeipa-enroll.service; enabled; vendor preset: enabled)
   Active: active (exited) since Tue 2020-06-02 21:42:18 UTC; 5h 24min ago
     Docs: man:ipa-client-install(8)
           https://www.freeipa.org/page/Client
  Process: 862 ExecStart=/usr/local/sbin/setup_freeipa.sh enroll (code=exited, status=0/SUCCESS)
 Main PID: 862 (code=exited, status=0/SUCCESS)

Jun 02 21:42:17 guac.env0.staging.cool.cyber.dhs.gov setup_freeipa.sh[862]: SSSD enabled
Jun 02 21:42:18 guac.env0.staging.cool.cyber.dhs.gov setup_freeipa.sh[862]: Configured /etc/openldap/ldap.conf
Jun 02 21:42:18 guac.env0.staging.cool.cyber.dhs.gov setup_freeipa.sh[862]: Configured /etc/ssh/ssh_config
Jun 02 21:42:18 guac.env0.staging.cool.cyber.dhs.gov setup_freeipa.sh[862]: Configured /etc/ssh/sshd_config
Jun 02 21:42:18 guac.env0.staging.cool.cyber.dhs.gov setup_freeipa.sh[862]: Configuring staging.cool.cyber.dhs.gov as NIS domain.
Jun 02 21:42:18 guac.env0.staging.cool.cyber.dhs.gov setup_freeipa.sh[862]: Client configuration complete.
Jun 02 21:42:18 guac.env0.staging.cool.cyber.dhs.gov setup_freeipa.sh[862]: The ipa-client-install command was successful
Jun 02 21:42:18 guac.env0.staging.cool.cyber.dhs.gov setup_freeipa.sh[862]: This program will set up FreeIPA client.
Jun 02 21:42:18 guac.env0.staging.cool.cyber.dhs.gov setup_freeipa.sh[862]: Version 4.7.2
Jun 02 21:42:18 guac.env0.staging.cool.cyber.dhs.gov systemd[1]: Started Handle enrollment and unenrollment of FreeIPA clients.
```
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
