### PR TITLE
Change the certificate location for the guacamole instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ the COOL environment.
 
 | Name | Description |
 |------|-------------|
+| guacamole_server | The AWS EC2 instance hosting guacamole. |
 | remote_desktop_url | The URL of the remote desktop gateway (Guacamole) for this assessment. |
 | ssm_session_role | An IAM role that allows creation of SSM SessionManager sessions to any EC2 instance in this account. |
 

--- a/cloud-init/install-certificates.py
+++ b/cloud-init/install-certificates.py
@@ -19,8 +19,8 @@ SERVER_FQDN = "${server_fqdn}"
 # These files will be copied from the bucket
 # and installed in the specified location.
 INSTALLATION_MAP = {
-    "fullchain.pem": "/var/guacamole/nginx/ssl/self.cert",
-    "privkey.pem": "/var/guacamole/nginx/ssl/self-ssl.key",
+    "fullchain.pem": "/var/guacamole/httpd/ssl/self.cert",
+    "privkey.pem": "/var/guacamole/httpd/ssl/self-ssl.key",
 }
 
 # Create STS client
@@ -42,15 +42,15 @@ s3 = boto3.client(
     aws_session_token=newsession_token,
 )
 
-# The guacamole-composition systemd service is guaranteed to start AFTER this
-# cloud-init script runs.  Therefore, we have to ensure that the nginx ssl
-# directory exists before we put the certificate files in there.
-# Also, since the guacamole-composition service has not started up (when
-# cloud-init executes this script), there's no need to restart it to use
-# the newly-deployed certificate.
+# The guacamole-composition systemd service is guaranteed to start
+# AFTER this cloud-init script runs.  Therefore, we have to ensure
+# that the httpd ssl directory exists before we put the certificate
+# files in there.  Also, since the guacamole-composition service has
+# not started up (when cloud-init executes this script), there's no
+# need to restart it to use the newly-deployed certificate.
 
-# Ensure nginx ssl directory exists before we put the cert files there
-os.makedirs("/var/guacamole/nginx/ssl/", exist_ok=True)
+# Ensure httpd ssl directory exists before we put the cert files there
+os.makedirs("/var/guacamole/httpd/ssl/", exist_ok=True)
 
 # Copy each file from the bucket to the local file system
 for src, dst in INSTALLATION_MAP.items():

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,8 @@
+output "guacamole_server" {
+  value       = aws_instance.guacamole
+  description = "The AWS EC2 instance hosting guacamole."
+}
+
 output "remote_desktop_url" {
   value       = "https://${aws_route53_record.guacamole_A.name}"
   description = "The URL of the remote desktop gateway (Guacamole) for this assessment."


### PR DESCRIPTION
## 🗣 Description

This pull request changes the location of the certificate that is used by the guacamole instance.

It also adds the guacamole EC2 instance as a Terraform output.  This is convenient when folks need to `ssh` to that instance and need to look up its EC2 instance ID.

See also:
* cisagov/guacamole-composition#9
* cisagov/ansible-role-httpd#2
* cisagov/ansible-role-guacamole#6

## 💭 Motivation and Context

We switched from nginx to Apache httpd for our reverse proxy, so the certificate location should reflect that change.

## 🧪 Testing

I used these changes to successfully deploy a kerberized version of guacamole to env0 in our staging environment.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
