### PR TITLE
Pin providers to major versions we have been using

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,4 +1,8 @@
-
 terraform {
   required_version = ">= 0.12"
+
+  required_providers {
+    aws      = "~> 2.0"
+    template = "~> 2.0"
+  }
 }


### PR DESCRIPTION
## 🗣 Description

This pull request pins Terraform providers to the major versions we have been using.

## 💭 Motivation and Context

This is in general a good practice, and we want to avoid version 3 of the AWS provider right now because it is a hot mess.

## 🧪 Testing

I successfully deployed to env1 in our staging environment with these changes.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
