### PR TITLE
Allow the operations subnet access to port 50050 on the teamservers

### DIFF
--- a/operations_acl_rules.tf
+++ b/operations_acl_rules.tf
@@ -98,10 +98,11 @@ resource "aws_network_acl_rule" "operations_ingress_from_anywhere_via_ports_3390
   to_port        = 5900
 }
 
-# Allow ingress from anywhere via ephemeral TCP/UDP ports above 5901 (5902-65535)
+# Allow ingress from anywhere via ephemeral TCP/UDP ports 5901-50049
 # For: Assessment team operational use, but don't want to allow
-#      public access to VNC on port 5901
-resource "aws_network_acl_rule" "operations_ingress_from_anywhere_via_ports_5902_thru_65535" {
+#      public access to VNC on port 5901 or Cobalt Strike teamserver
+#      on port 50050
+resource "aws_network_acl_rule" "operations_ingress_from_anywhere_via_ports_5902_thru_50049" {
   provider = aws.provisionassessment
   for_each = toset(local.tcp_and_udp)
 
@@ -112,6 +113,23 @@ resource "aws_network_acl_rule" "operations_ingress_from_anywhere_via_ports_5902
   rule_action    = "allow"
   cidr_block     = "0.0.0.0/0"
   from_port      = 5902
+  to_port        = 50049
+}
+
+# Allow ingress from anywhere via ephemeral TCP/UDP ports 50051-65535
+# For: Assessment team operational use, but don't want to allow
+#      public access to Cobalt Strike teamserver on port 50050
+resource "aws_network_acl_rule" "operations_ingress_from_anywhere_via_ports_50051_thru_65535" {
+  provider = aws.provisionassessment
+  for_each = toset(local.tcp_and_udp)
+
+  network_acl_id = aws_network_acl.operations.id
+  egress         = false
+  protocol       = each.value
+  rule_number    = 306 + index(local.tcp_and_udp, each.value)
+  rule_action    = "allow"
+  cidr_block     = "0.0.0.0/0"
+  from_port      = 50051
   to_port        = 65535
 }
 

--- a/operations_sg_rules.tf
+++ b/operations_sg_rules.tf
@@ -24,7 +24,8 @@ resource "aws_security_group_rule" "operations_ingress_from_guacamole_via_vnc" {
   to_port           = 5901
 }
 
-# Allow ingress from Kali instances via port 993 (IMAP over TLS/SSL)
+# Allow ingress from Kali instances to teamservers via port 993 (IMAP
+# over TLS/SSL)
 # For: Assessment team IMAP access on Teamservers from Kali instances
 resource "aws_security_group_rule" "operations_ingress_from_kali_via_imaps" {
   count    = lookup(var.operations_instance_counts, "teamserver", 0) > 0 ? 1 : 0
@@ -50,6 +51,22 @@ resource "aws_security_group_rule" "operations_ingress_from_kali_for_nessus" {
   cidr_blocks       = formatlist("%s/32", aws_instance.kali[*].private_ip)
   from_port         = 8834
   to_port           = 8834
+}
+
+# Allow ingress from Kali instances to teamservers via port 50050
+# (Cobalt Strike)
+# For: Assessment team to access Cobalt Strike on Teamservers from
+# Kali instances
+resource "aws_security_group_rule" "operations_ingress_from_kali_via_cs" {
+  count    = lookup(var.operations_instance_counts, "teamserver", 0) > 0 ? 1 : 0
+  provider = aws.provisionassessment
+
+  security_group_id = aws_security_group.operations.id
+  type              = "ingress"
+  protocol          = "tcp"
+  cidr_blocks       = formatlist("%s/32", aws_instance.kali[*].private_ip)
+  from_port         = 50050
+  to_port           = 50050
 }
 
 # Allow ingress from anywhere via the TCP ports specified in


### PR DESCRIPTION
## 🗣 Description

In this pull request I modify the NACL and security group configurations for the operations subnet to allow the Kali instances access via port 50050.

## 💭 Motivation and Context

The assessors on Kali instances in the COOL need to be able to access Cobalt Strike running on the teamservers.

See also cisagov/teamserver-packer#15.

## 🧪 Testing

This change was tested in our staging COOL environment.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
