### PR TITLE
Upgrade to version 3 of Terraform AWS provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,19 +67,19 @@ the COOL environment.
 | Name | Version |
 |------|---------|
 | terraform | ~> 0.12.0 |
-| aws | ~> 2.0 |
+| aws | ~> 3.0 |
 | template | ~> 2.1 |
 
 ## Providers ##
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
-| aws.dns_sharedservices | ~> 2.0 |
-| aws.organizationsreadonly | ~> 2.0 |
-| aws.provisionassessment | ~> 2.0 |
-| aws.provisionparameterstorereadrole | ~> 2.0 |
-| aws.provisionsharedservices | ~> 2.0 |
+| aws | ~> 3.0 |
+| aws.dns_sharedservices | ~> 3.0 |
+| aws.organizationsreadonly | ~> 3.0 |
+| aws.provisionassessment | ~> 3.0 |
+| aws.provisionparameterstorereadrole | ~> 3.0 |
+| aws.provisionsharedservices | ~> 3.0 |
 | template | ~> 2.1 |
 | terraform | n/a |
 

--- a/guacamole_iam.tf
+++ b/guacamole_iam.tf
@@ -1,6 +1,6 @@
 # Create a role that allows the instance to read its certs from S3.
 module "guacamole_certreadrole" {
-  source = "github.com/cisagov/cert-read-role-tf-module"
+  source = "github.com/cisagov/cert-read-role-tf-module?ref=test_tf_aws_provider_v3"
 
   providers = {
     aws = aws.provisioncertreadrole

--- a/guacamole_iam.tf
+++ b/guacamole_iam.tf
@@ -1,6 +1,6 @@
 # Create a role that allows the instance to read its certs from S3.
 module "guacamole_certreadrole" {
-  source = "github.com/cisagov/cert-read-role-tf-module?ref=test_tf_aws_provider_v3"
+  source = "github.com/cisagov/cert-read-role-tf-module"
 
   providers = {
     aws = aws.provisioncertreadrole

--- a/versions.tf
+++ b/versions.tf
@@ -6,7 +6,7 @@ terraform {
   # major version currently being used.  This practice will help us
   # avoid unwelcome surprises.
   required_providers {
-    aws      = "~> 2.0"
+    aws      = "~> 3.0"
     template = "~> 2.1"
   }
 }


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR moves this repo from using version 2 to version 3 of the [Terraform AWS provider](https://github.com/terraform-providers/terraform-provider-aws).

<!--- Describe your changes in detail -->

## 💭 Motivation and Context
Version 3 of the AWS provider appears to have stabilized, so it seems like a good time for us to jump on board.

It will also allow us to resolve https://github.com/cisagov/cool-assessment-terraform/issues/7 by taking advantage of https://github.com/terraform-providers/terraform-provider-aws/pull/14215.

I will keep this PR as a draft until https://github.com/cisagov/cert-read-role-tf-module/pull/19 is merged.  After that, I will revert https://github.com/cisagov/cool-assessment-terraform/commit/c25b9d4cde1d208002f409cc574c494facf7c0bf, finalize this PR, and request review.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
* All automated tests pass.
* The Terraform in this repo was successfully applied and destroyed in a Staging environment (while [using the version 3 branch of cert-read-role-tf-module](https://github.com/cisagov/cool-assessment-terraform/commit/c25b9d4cde1d208002f409cc574c494facf7c0bf)).

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
