### PR TITLE
Automate association of assessment VPC with Shared Services private DNS zone

### DIFF
--- a/provisionassessment_policy.tf
+++ b/provisionassessment_policy.tf
@@ -121,6 +121,7 @@ data "aws_iam_policy_document" "provisionassessment_policy_doc" {
       "route53:DeleteHostedZone",
       "route53:GetChange",
       "route53:GetHostedZone",
+      "route53:ListHostedZonesByVPC",
       "route53:ListResourceRecordSets",
       "route53:ListTagsForResource",
       "route53:UpdateHostedZoneComment",

--- a/route53.tf
+++ b/route53.tf
@@ -39,3 +39,18 @@ resource "aws_route53_zone" "private_subnet_reverse" {
     vpc_id = aws_vpc.assessment.id
   }
 }
+
+# Associate assessment VPC with Shared Services Route53 (private DNS) zone
+resource "aws_route53_vpc_association_authorization" "assessment_public" {
+  provider = aws.dns_sharedservices
+
+  vpc_id  = aws_vpc.assessment.id
+  zone_id = data.terraform_remote_state.sharedservices_networking.outputs.private_zone.id
+}
+
+resource "aws_route53_zone_association" "assessment_public" {
+  provider = aws.provisionassessment
+
+  vpc_id  = aws_route53_vpc_association_authorization.assessment_public.vpc_id
+  zone_id = aws_route53_vpc_association_authorization.assessment_public.zone_id
+}


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR automates the process of associating the assessment VPC with the private DNS zone in the Shared Services account.

<!--- Describe your changes in detail -->

## 💭 Motivation and Context
Automating this association was not possible until the release of [version 3.1.0 of the Terraform AWS provider](https://github.com/terraform-providers/terraform-provider-aws/blob/v3.1.0/CHANGELOG.md).  Now that https://github.com/cisagov/cool-assessment-terraform/pull/69 upgraded this repo to version 3.x of the AWS provider, we are able to implement this change.

This change will eliminate the manual steps in the ["Associate Shared Services DNS with new environment"](https://github.com/cisagov/cool-system/wiki/Provisioning-New-Environments#associate-shared-services-dns-with-new-environment) section of our ["Provisioning New Environments" documentation](https://github.com/cisagov/cool-system/wiki/Provisioning-New-Environments).

Resolves #7.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
Here's how I tested this change in `env1-staging`:
* Via the AWS web console, I verified that the assessment VPC was associated with the Shared Services private DNS zone (this association had been previously done manually).
* Via the AWS web console, I manually disassociated the assessment VPC from the Shared Services private DNS zone and confirmed the disassociation was successful.
* I successfully ran a `terraform apply` and verified (via the AWS web console) that the assessment VPC from `env1-staging` was indeed associated with the Shared Services private DNS zone, as expected.
* I successfully ran a targeted `terraform destroy` on the newly-created `aws_route53_vpc_association_authorization.assessment_public` and `aws_route53_zone_association.assessment_public` resources and verified (via the AWS web console) that the assessment VPC from `env1-staging` was disassociated from the Shared Services private DNS zone, as expected.  This is excellent because we previously had to remember to manually disassociate the VPC when tearing down an environment at the end of an assessment.

Also, all automated tests passed.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation (not the documentation in this repo, but the [Wiki documentation](https://github.com/cisagov/cool-system/wiki/Provisioning-New-Environments#associate-shared-services-dns-with-new-environment) mentioned above).
- [ ] I have updated the documentation accordingly. -> NOTE: I will remove the [steps in the Wiki documentation](https://github.com/cisagov/cool-system/wiki/Provisioning-New-Environments#associate-shared-services-dns-with-new-environment) after this PR is merged.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
