### PR TITLE
Automate disassociation of the transit gateway attachment and transit gateway default route table

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ the COOL environment.
 |------|---------|
 | terraform | ~> 0.12.0 |
 | aws | ~> 3.0 |
+| null | ~> 3.0 |
 | template | ~> 2.1 |
 
 ## Providers ##
@@ -80,6 +81,7 @@ the COOL environment.
 | aws.provisionassessment | ~> 3.0 |
 | aws.provisionparameterstorereadrole | ~> 3.0 |
 | aws.provisionsharedservices | ~> 3.0 |
+| null | ~> 3.0 |
 | template | ~> 2.1 |
 | terraform | n/a |
 

--- a/locals.tf
+++ b/locals.tf
@@ -156,6 +156,9 @@ locals {
 
   # The ID of the Transit Gateway in the Shared Services account.
   transit_gateway_id = data.terraform_remote_state.sharedservices_networking.outputs.transit_gateway.id
+  # The ID of the default route table associated with the Transit
+  # Gateway in the Shared Services account.
+  transit_gateway_default_route_table_id = data.terraform_remote_state.sharedservices_networking.outputs.transit_gateway.association_default_route_table_id
   # The ID of the route table to be associated with the Transit
   # Gateway attachment for this account.
   transit_gateway_route_table_id = data.terraform_remote_state.sharedservices_networking.outputs.transit_gateway_attachment_route_tables[local.assessment_account_id].id

--- a/locals.tf
+++ b/locals.tf
@@ -154,7 +154,7 @@ locals {
     "udp",
   ]
 
-  # The ID of the Transit Gateway in the Shared Services account
+  # The ID of the Transit Gateway in the Shared Services account.
   transit_gateway_id = data.terraform_remote_state.sharedservices_networking.outputs.transit_gateway.id
   # The ID of the route table to be associated with the Transit
   # Gateway attachment for this account.

--- a/transitgateway.tf
+++ b/transitgateway.tf
@@ -26,7 +26,37 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "assessment" {
   vpc_id             = aws_vpc.assessment.id
 }
 
+# Break the association between the transit gateway VPC attachment and
+# the default transit gateway route table.
+#
+# It would be nice not to have to use the Terraform escape hatch for
+# this, but Terraform just doesn't support this sort of cross-account
+# foo right now.
+resource "null_resource" "break_association_with_default_route_table" {
+  # Require that the transit gateway VPC attachment is created before
+  # breaking the association.
+  depends_on = [
+    aws_ec2_transit_gateway_vpc_attachment.assessment,
+  ]
+
+  provisioner "local-exec" {
+    when = create
+    # This command asks AWS to disassociate the default route table
+    # from our transit gateway attachment, then loops until the
+    # disassociation is complete.
+    command = "aws --profile cool-sharedservices-provisionaccount ec2 disassociate-transit-gateway-route-table --transit-gateway-route-table-id ${local.transit_gateway_default_route_table_id} --transit-gateway-attachment-id ${aws_ec2_transit_gateway_vpc_attachment.assessment.id} && while aws --profile cool-sharedservices-provisionaccount ec2 get-transit-gateway-route-table-associations --transit-gateway-route-table-id ${local.transit_gateway_default_route_table_id} | grep --quiet ${aws_vpc.assessment.id}; do sleep 5s; done"
+  }
+
+  triggers = {
+    tgw_default_route_table_id = local.transit_gateway_default_route_table_id
+    tgw_vpc_attachment_id      = aws_ec2_transit_gateway_vpc_attachment.assessment.id
+  }
+}
+
 resource "aws_ec2_transit_gateway_route_table_association" "association" {
+  depends_on = [
+    null_resource.break_association_with_default_route_table,
+  ]
   provider = aws.provisionsharedservices
 
   transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.assessment.id

--- a/versions.tf
+++ b/versions.tf
@@ -7,6 +7,7 @@ terraform {
   # avoid unwelcome surprises.
   required_providers {
     aws      = "~> 3.0"
+    null     = "~> 3.0"
     template = "~> 2.1"
   }
 }

--- a/vpc.tf
+++ b/vpc.tf
@@ -36,28 +36,3 @@ resource "aws_vpc_dhcp_options_association" "assessment" {
   dhcp_options_id = aws_vpc_dhcp_options.assessment.id
   vpc_id          = aws_vpc.assessment.id
 }
-
-# # Associate the COOL private DNS zone with this VPC
-#
-# Not available right now in Terraform
-# See https://github.com/cisagov/cool-assessment-terraform/issues/7
-# for details.
-#
-# For now, I manually executed:
-# aws route53 create-vpc-association-authorization \
-# --hosted-zone-id COOLPRIVATEZONEID \
-# --vpc VPCRegion=us-east-1,VPCId=vpc-MY_ENV_VPC_ID \
-# --profile cool-sharedservices-provisionaccount
-#
-# aws route53 associate-vpc-with-hosted-zone \
-# --hosted-zone-id COOLPRIVATEZONEID \
-# --vpc VPCRegion=us-east-1,VPCId=vpc-MY_ENV_VPC_ID \
-# --profile cool-MYENV-provisionaccount
-#
-#
-# resource "aws_route53_zone_association" "cool_private" {
-#   provider = aws.provisionassessment
-#
-#   vpc_id  = aws_vpc.assessment.id
-#   zone_id = local.cool_dns_private_zone.zone_id
-# }


### PR DESCRIPTION
## 🗣 Description

In this pull request I automate the disassociation of the transit gateway attachment for this VPC from the default route table of the transit gateway in the Shared Services account.

Closes #57.

## 💭 Motivation and Context

This disassociation was previously a manual step.  Automating it makes the creation of a new assessment environment easier and removes the possibility of potentially-destructive human errors.

## 🧪 Testing

I have successfully deployed an assessment environment to our COOL staging environment with these changes.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the `README.md` documentation accordingly.
- [ ] I have updated the [cisagov/cool-system](https://github.com/cisagov/cool-system/wiki/Provisioning-New-Environments#correct-transit-gateway-route-table-association) documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
