### PR TITLE
Specify region when disassociating default route table from TG attachment

### DIFF
--- a/transitgateway.tf
+++ b/transitgateway.tf
@@ -44,7 +44,7 @@ resource "null_resource" "break_association_with_default_route_table" {
     # This command asks AWS to disassociate the default route table
     # from our transit gateway attachment, then loops until the
     # disassociation is complete.
-    command = "aws --profile cool-sharedservices-provisionaccount ec2 disassociate-transit-gateway-route-table --transit-gateway-route-table-id ${local.transit_gateway_default_route_table_id} --transit-gateway-attachment-id ${aws_ec2_transit_gateway_vpc_attachment.assessment.id} && while aws --profile cool-sharedservices-provisionaccount ec2 get-transit-gateway-route-table-associations --transit-gateway-route-table-id ${local.transit_gateway_default_route_table_id} | grep --quiet ${aws_vpc.assessment.id}; do sleep 5s; done"
+    command = "aws --profile cool-sharedservices-provisionaccount --region ${var.aws_region} ec2 disassociate-transit-gateway-route-table --transit-gateway-route-table-id ${local.transit_gateway_default_route_table_id} --transit-gateway-attachment-id ${aws_ec2_transit_gateway_vpc_attachment.assessment.id} && while aws --profile cool-sharedservices-provisionaccount --region ${var.aws_region} ec2 get-transit-gateway-route-table-associations --transit-gateway-route-table-id ${local.transit_gateway_default_route_table_id} | grep --quiet ${aws_vpc.assessment.id}; do sleep 5s; done"
   }
 
   triggers = {


### PR DESCRIPTION


# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR explicitly specifies the AWS region when disassociating the default route table from the transit gateway attachment.

<!--- Describe your changes in detail -->

## 💭 Motivation and Context
Before this change, the Terraforming user had to specify the region in an environment variable (e.g. AWS_DEFAULT_REGION) or else the `aws` commands would return an error.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
In an environment that needed to execute the `null_resource.break_association_with_default_route_table` code, I verified that I was able to run a successful `terraform apply` without defining the `AWS_DEFAULT_REGION` environment variable.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
