### PR TITLE
Allow ingress from Kali instances to Pentest Portal instances via port 8080

### DIFF
--- a/pentestportal_sg_rules.tf
+++ b/pentestportal_sg_rules.tf
@@ -39,6 +39,21 @@ resource "aws_security_group_rule" "pentestportal_ingress_from_kali_via_https" {
   to_port           = 443
 }
 
+# Allow ingress from Kali instances via port 8080
+# For: Assessment team "development mode" access to pentest portal from
+# Kali instances
+resource "aws_security_group_rule" "pentestportal_ingress_from_kali_via_8080" {
+  count    = lookup(var.operations_instance_counts, "pentestportal", 0) > 0 ? 1 : 0
+  provider = aws.provisionassessment
+
+  security_group_id = aws_security_group.pentestportal.id
+  type              = "ingress"
+  protocol          = "tcp"
+  cidr_blocks       = formatlist("%s/32", aws_instance.kali[*].private_ip)
+  from_port         = 8080
+  to_port           = 8080
+}
+
 # Allow egress to anywhere via HTTP and HTTPS
 # For: Pentest portal installation dependencies
 resource "aws_security_group_rule" "pentestportal_egress_to_anywhere_via_allowed_ports" {

--- a/pentestportal_sg_rules.tf
+++ b/pentestportal_sg_rules.tf
@@ -34,7 +34,7 @@ resource "aws_security_group_rule" "pentestportal_ingress_from_kali_via_https" {
   security_group_id = aws_security_group.pentestportal.id
   type              = "ingress"
   protocol          = "tcp"
-  cidr_blocks       = formatlist("%s/32", aws_instance.kali[*].private_ip)
+  cidr_blocks       = [for instance in aws_instance.kali : format("%s/32", instance.private_ip)]
   from_port         = 443
   to_port           = 443
 }
@@ -49,7 +49,7 @@ resource "aws_security_group_rule" "pentestportal_ingress_from_kali_via_8080" {
   security_group_id = aws_security_group.pentestportal.id
   type              = "ingress"
   protocol          = "tcp"
-  cidr_blocks       = formatlist("%s/32", aws_instance.kali[*].private_ip)
+  cidr_blocks       = [for instance in aws_instance.kali : format("%s/32", instance.private_ip)]
   from_port         = 8080
   to_port           = 8080
 }


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR adds a new security group rule that allows TCP traffic on port 8080 from the Kali instances in the Operations subnet to the Pentest Portal instances in the same subnet.

<!--- Describe your changes in detail -->

## 💭 Motivation and Context
This was requested by the assessment team in https://github.com/cisagov/cool-system/issues/96.
Closes https://github.com/cisagov/cool-system/issues/96.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
I applied the changes in an environment and manually verified that the new security group rules appeared as expected in the AWS web console.  I also verified that there are no rules allowing public access to port 8080 on the Pentest Portal instances.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
