### PR TITLE
Stop using deprecated provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ the COOL environment.
 |------|---------|
 | terraform | ~> 0.12.0 |
 | aws | ~> 3.0 |
+| cloudinit | ~> 2.0 |
 | null | ~> 3.0 |
-| template | ~> 2.1 |
 
 ## Providers ##
 
@@ -81,8 +81,8 @@ the COOL environment.
 | aws.provisionassessment | ~> 3.0 |
 | aws.provisionparameterstorereadrole | ~> 3.0 |
 | aws.provisionsharedservices | ~> 3.0 |
+| cloudinit | ~> 2.0 |
 | null | ~> 3.0 |
-| template | ~> 2.1 |
 | terraform | n/a |
 
 ## Inputs ##

--- a/gophish_cloud_init.tf
+++ b/gophish_cloud_init.tf
@@ -1,6 +1,6 @@
 # cloud-init commands for configuring GoPhish instances
 
-data "template_cloudinit_config" "gophish_cloud_init_tasks" {
+data "cloudinit_config" "gophish_cloud_init_tasks" {
   count = lookup(var.operations_instance_counts, "gophish", 0)
 
   gzip          = true

--- a/gophish_ec2.tf
+++ b/gophish_ec2.tf
@@ -41,7 +41,7 @@ resource "aws_instance" "gophish" {
     delete_on_termination = true
   }
 
-  user_data_base64 = data.template_cloudinit_config.gophish_cloud_init_tasks[count.index].rendered
+  user_data_base64 = data.cloudinit_config.gophish_cloud_init_tasks[count.index].rendered
 
   vpc_security_group_ids = [
     aws_security_group.efs_client.id,

--- a/guacamole_cloud_init.tf
+++ b/guacamole_cloud_init.tf
@@ -1,6 +1,6 @@
 # cloud-init commands for configuring Guacamole instance
 
-data "template_cloudinit_config" "guacamole_cloud_init_tasks" {
+data "cloudinit_config" "guacamole_cloud_init_tasks" {
   gzip          = true
   base64_encode = true
 

--- a/guacamole_ec2.tf
+++ b/guacamole_ec2.tf
@@ -39,7 +39,7 @@ resource "aws_instance" "guacamole" {
     delete_on_termination = true
   }
 
-  user_data_base64 = data.template_cloudinit_config.guacamole_cloud_init_tasks.rendered
+  user_data_base64 = data.cloudinit_config.guacamole_cloud_init_tasks.rendered
 
   vpc_security_group_ids = [
     aws_security_group.desktop_gateway.id,

--- a/kali_cloud_init.tf
+++ b/kali_cloud_init.tf
@@ -1,6 +1,6 @@
 # cloud-init commands for configuring Kali instances
 
-data "template_cloudinit_config" "kali_cloud_init_tasks" {
+data "cloudinit_config" "kali_cloud_init_tasks" {
   gzip          = true
   base64_encode = true
 

--- a/kali_ec2.tf
+++ b/kali_ec2.tf
@@ -41,7 +41,7 @@ resource "aws_instance" "kali" {
     delete_on_termination = true
   }
 
-  user_data_base64 = data.template_cloudinit_config.kali_cloud_init_tasks.rendered
+  user_data_base64 = data.cloudinit_config.kali_cloud_init_tasks.rendered
 
   vpc_security_group_ids = [
     aws_security_group.efs_client.id,

--- a/nessus_cloud_init.tf
+++ b/nessus_cloud_init.tf
@@ -1,6 +1,6 @@
 # cloud-init commands for configuring Nessus instances
 
-data "template_cloudinit_config" "nessus_cloud_init_tasks" {
+data "cloudinit_config" "nessus_cloud_init_tasks" {
   count = lookup(var.operations_instance_counts, "nessus", 0)
 
   gzip          = true

--- a/nessus_ec2.tf
+++ b/nessus_ec2.tf
@@ -46,7 +46,7 @@ resource "aws_instance" "nessus" {
     delete_on_termination = true
   }
 
-  user_data_base64 = data.template_cloudinit_config.nessus_cloud_init_tasks[count.index].rendered
+  user_data_base64 = data.cloudinit_config.nessus_cloud_init_tasks[count.index].rendered
 
   vpc_security_group_ids = [
     aws_security_group.operations.id

--- a/pentestportal_ec2.tf
+++ b/pentestportal_ec2.tf
@@ -43,7 +43,7 @@ resource "aws_instance" "pentestportal" {
 
   # We can use the same cloud-init code as the Kali instances, since
   # all it does is set up /etc/fstab to mount the EFS file share.
-  user_data_base64 = data.template_cloudinit_config.kali_cloud_init_tasks.rendered
+  user_data_base64 = data.cloudinit_config.kali_cloud_init_tasks.rendered
 
   # Even though the pentest portal instances are in the Operations subnet,
   # we put them in the "pentestportal" security group.  This means that the

--- a/teamserver_ec2.tf
+++ b/teamserver_ec2.tf
@@ -43,7 +43,7 @@ resource "aws_instance" "teamserver" {
 
   # We can use the same cloud-init code as the Kali instances, since
   # all it does is set up /etc/fstab to mount the EFS file share.
-  user_data_base64 = data.template_cloudinit_config.kali_cloud_init_tasks.rendered
+  user_data_base64 = data.cloudinit_config.kali_cloud_init_tasks.rendered
 
   vpc_security_group_ids = [
     aws_security_group.efs_client.id,

--- a/versions.tf
+++ b/versions.tf
@@ -6,8 +6,8 @@ terraform {
   # major version currently being used.  This practice will help us
   # avoid unwelcome surprises.
   required_providers {
-    aws      = "~> 3.0"
-    null     = "~> 3.0"
-    template = "~> 2.1"
+    aws       = "~> 3.0"
+    cloudinit = "~> 2.0"
+    null      = "~> 3.0"
   }
 }


### PR DESCRIPTION
## 🗣 Description

This pull request gets rid of the deprecated [template Terraform provider](https://registry.terraform.io/providers/hashicorp/template/latest/docs) in favor of the [cloudinit Terraform provider](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs).

## 💭 Motivation and Context

The deprecated template provider could disappear altogether at any time.

## 🧪 Testing

All pre-commit hooks pass.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)
- [x] Halt the ever-advancing threat of obsolescence

## ✅ Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
