### PR TITLE
Make Guacamole connections for PTP instances use 1-based indexing

### DIFF
--- a/pentestportal_ec2.tf
+++ b/pentestportal_ec2.tf
@@ -56,8 +56,8 @@ resource "aws_instance" "pentestportal" {
     aws_security_group.pentestportal.id,
   ]
 
-  tags        = merge(var.tags, map("Name", format("PentestPortal%d", count.index)))
-  volume_tags = merge(var.tags, map("Name", format("PentestPortal%d", count.index)))
+  tags        = merge(var.tags, map("Name", format("PentestPortal%d", count.index + 1)))
+  volume_tags = merge(var.tags, map("Name", format("PentestPortal%d", count.index + 1)))
 }
 
 # The Elastic IP for each pentest portal instance
@@ -69,7 +69,7 @@ resource "aws_eip" "pentestportal" {
   tags = merge(
     var.tags,
     {
-      "Name"           = format("PentestPortal%d EIP", count.index)
+      "Name"           = format("PentestPortal%d EIP", count.index + 1)
       "Publish Egress" = "False"
     },
   )

--- a/pentestportal_route53.tf
+++ b/pentestportal_route53.tf
@@ -4,7 +4,7 @@ resource "aws_route53_record" "pentestportal_A" {
   provider = aws.provisionassessment
 
   zone_id = aws_route53_zone.assessment_private.zone_id
-  name    = "pentestportal${count.index}.${aws_route53_zone.assessment_private.name}"
+  name    = "pentestportal${count.index + 1}.${aws_route53_zone.assessment_private.name}"
   type    = "A"
   ttl     = var.dns_ttl
   records = [aws_instance.pentestportal[count.index].private_ip]


### PR DESCRIPTION
## 🗣 Description

In this pull request I:
* Change DNS A records for Pentest Portal EC2 instances so that the Pentest Portal connections in Guacamole use 1-based indexing.  ([The A records are used to create the Guacamole connections via cloud-init at startup](https://github.com/cisagov/cool-assessment-terraform/blob/develop/guacamole_cloud_init.tf#L83).)
* Update the tags associated with the Pentest Portal EC2 and EIP resources to agree with the new 1-based indexing.

## 💭 Motivation and Context

One of the assessment Fed leads asked that the Pentest Portal Guacamole connections be changed to use 1-based indexing.  This is because they currently assign a single Pentest Portal EC2 instance per customer (due to inherent limitations of the Pentest Portal Docker image) and a 1-based indexing scheme makes the Guacamole connections match up with the internal document they use to list the customers assigned to a particular assessment team.

This pull request resolves #81.

## 🧪 Testing

I deployed these changes to env0 in our COOL staging environment and verified that they work as expected.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
