### PR TITLE
Security group rules cleanup

### DIFF
--- a/debiandesktop_sg_rules.tf
+++ b/debiandesktop_sg_rules.tf
@@ -47,7 +47,7 @@ resource "aws_security_group_rule" "debiandesktop_egress_to_nessus_via_gui_port"
 # Allow egress to anywhere via HTTP and HTTPS
 # For: Operator web access, package downloads and updates
 resource "aws_security_group_rule" "debiandesktop_egress_to_anywhere_via_allowed_ports" {
-  for_each = toset([for port in ["80", "443"] : port if lookup(var.operations_instance_counts, "debiandesktop", 0) > 0])
+  for_each = lookup(var.operations_instance_counts, "debiandesktop", 0) > 0 ? toset(["80", "443"]) : toset([])
   provider = aws.provisionassessment
 
   security_group_id = aws_security_group.debiandesktop.id

--- a/debiandesktop_sg_rules.tf
+++ b/debiandesktop_sg_rules.tf
@@ -1,6 +1,7 @@
 # Allow ingress from Guacamole instance via ssh
 # For: DevOps ssh access from Guacamole instance to Debian desktop instance
 resource "aws_security_group_rule" "debiandesktop_ingress_from_guacamole_via_ssh" {
+  count    = lookup(var.operations_instance_counts, "debiandesktop", 0) > 0 ? 1 : 0
   provider = aws.provisionassessment
 
   security_group_id = aws_security_group.debiandesktop.id
@@ -15,6 +16,7 @@ resource "aws_security_group_rule" "debiandesktop_ingress_from_guacamole_via_ssh
 # For: Assessment team VNC access from Guacamole instance to Debian desktop
 # instance
 resource "aws_security_group_rule" "debiandesktop_ingress_from_guacamole_via_vnc" {
+  count    = lookup(var.operations_instance_counts, "debiandesktop", 0) > 0 ? 1 : 0
   provider = aws.provisionassessment
 
   security_group_id = aws_security_group.debiandesktop.id
@@ -27,8 +29,11 @@ resource "aws_security_group_rule" "debiandesktop_ingress_from_guacamole_via_vnc
 
 # Allow egress from Debian desktop instances via Nessus web GUI port (8834)
 # For: Operator Nessus web access from Debian desktop instances
-resource "aws_security_group_rule" "debiandesktop_egress_to_nessus_" {
-  count    = lookup(var.operations_instance_counts, "debiandesktop", 0) > 0 ? 1 : 0
+#
+# NOTE: This rule will only be created if there is at least one Nessus instance
+# and at least one Debian Desktop instance.
+resource "aws_security_group_rule" "debiandesktop_egress_to_nessus_via_gui_port" {
+  count    = lookup(var.operations_instance_counts, "debiandesktop", 0) * lookup(var.operations_instance_counts, "nessus", 0) > 0 ? 1 : 0
   provider = aws.provisionassessment
 
   security_group_id = aws_security_group.debiandesktop.id
@@ -42,8 +47,8 @@ resource "aws_security_group_rule" "debiandesktop_egress_to_nessus_" {
 # Allow egress to anywhere via HTTP and HTTPS
 # For: Operator web access, package downloads and updates
 resource "aws_security_group_rule" "debiandesktop_egress_to_anywhere_via_allowed_ports" {
+  for_each = toset([for port in ["80", "443"] : port if lookup(var.operations_instance_counts, "debiandesktop", 0) > 0])
   provider = aws.provisionassessment
-  for_each = toset(["80", "443"])
 
   security_group_id = aws_security_group.debiandesktop.id
   type              = "egress"

--- a/operations_sg_rules.tf
+++ b/operations_sg_rules.tf
@@ -37,7 +37,7 @@ resource "aws_security_group_rule" "operations_ingress_from_kali_via_imaps" {
   security_group_id = aws_security_group.operations.id
   type              = "ingress"
   protocol          = "tcp"
-  cidr_blocks       = formatlist("%s/32", aws_instance.kali[*].private_ip)
+  cidr_blocks       = [for instance in aws_instance.kali : format("%s/32", instance.private_ip)]
   from_port         = 993
   to_port           = 993
 }
@@ -73,7 +73,7 @@ resource "aws_security_group_rule" "operations_ingress_from_kali_via_cs" {
   security_group_id = aws_security_group.operations.id
   type              = "ingress"
   protocol          = "tcp"
-  cidr_blocks       = formatlist("%s/32", aws_instance.kali[*].private_ip)
+  cidr_blocks       = [for instance in aws_instance.kali : format("%s/32", instance.private_ip)]
   from_port         = 50050
   to_port           = 50050
 }

--- a/operations_sg_rules.tf
+++ b/operations_sg_rules.tf
@@ -27,8 +27,11 @@ resource "aws_security_group_rule" "operations_ingress_from_guacamole_via_vnc" {
 # Allow ingress from Kali instances to teamservers via port 993 (IMAP
 # over TLS/SSL)
 # For: Assessment team IMAP access on Teamservers from Kali instances
+#
+# NOTE: This rule will only be created if there is at least one Kali instance
+# and at least one Teamserver instance.
 resource "aws_security_group_rule" "operations_ingress_from_kali_via_imaps" {
-  count    = lookup(var.operations_instance_counts, "teamserver", 0) > 0 ? 1 : 0
+  count    = lookup(var.operations_instance_counts, "kali", 0) * lookup(var.operations_instance_counts, "teamserver", 0) > 0 ? 1 : 0
   provider = aws.provisionassessment
 
   security_group_id = aws_security_group.operations.id
@@ -41,8 +44,11 @@ resource "aws_security_group_rule" "operations_ingress_from_kali_via_imaps" {
 
 # Allow ingress from Kali and Debian desktop instances via Nessus web GUI
 # For: Assessment team Nessus web access from Kali and Debian desktop instances
+#
+# NOTE: This rule will only be created if there is at least one Nessus instance
+# and at least one Kali or Debian Desktop instance.
 resource "aws_security_group_rule" "operations_ingress_from_allowed_instances_for_nessus" {
-  count    = lookup(var.operations_instance_counts, "nessus", 0) > 0 ? 1 : 0
+  count    = lookup(var.operations_instance_counts, "nessus", 0) * (lookup(var.operations_instance_counts, "kali", 0) + lookup(var.operations_instance_counts, "debiandesktop", 0)) > 0 ? 1 : 0
   provider = aws.provisionassessment
 
   security_group_id = aws_security_group.operations.id
@@ -57,8 +63,11 @@ resource "aws_security_group_rule" "operations_ingress_from_allowed_instances_fo
 # (Cobalt Strike)
 # For: Assessment team to access Cobalt Strike on Teamservers from
 # Kali instances
+#
+# NOTE: This rule will only be created if there is at least one Kali instance
+# and at least one Teamserver instance.
 resource "aws_security_group_rule" "operations_ingress_from_kali_via_cs" {
-  count    = lookup(var.operations_instance_counts, "teamserver", 0) > 0 ? 1 : 0
+  count    = lookup(var.operations_instance_counts, "kali", 0) * lookup(var.operations_instance_counts, "teamserver", 0) > 0 ? 1 : 0
   provider = aws.provisionassessment
 
   security_group_id = aws_security_group.operations.id

--- a/pentestportal_sg_rules.tf
+++ b/pentestportal_sg_rules.tf
@@ -1,6 +1,7 @@
 # Allow ingress from Guacamole instance via ssh
 # For: DevOps ssh access from Guacamole instance to pentest portal instance
 resource "aws_security_group_rule" "pentestportal_ingress_from_guacamole_via_ssh" {
+  count    = lookup(var.operations_instance_counts, "pentestportal", 0) > 0 ? 1 : 0
   provider = aws.provisionassessment
 
   security_group_id = aws_security_group.pentestportal.id
@@ -15,6 +16,7 @@ resource "aws_security_group_rule" "pentestportal_ingress_from_guacamole_via_ssh
 # For: Assessment team VNC access from Guacamole instance to pentest portal
 # instance
 resource "aws_security_group_rule" "pentestportal_ingress_from_guacamole_via_vnc" {
+  count    = lookup(var.operations_instance_counts, "pentestportal", 0) > 0 ? 1 : 0
   provider = aws.provisionassessment
 
   security_group_id = aws_security_group.pentestportal.id
@@ -27,8 +29,11 @@ resource "aws_security_group_rule" "pentestportal_ingress_from_guacamole_via_vnc
 
 # Allow ingress from Kali instances via port 443
 # For: Assessment team HTTPS access to pentest portal from Kali instances
+#
+# NOTE: This rule will only be created if there is at least one Pentest Portal
+# instance and at least one Kali instance.
 resource "aws_security_group_rule" "pentestportal_ingress_from_kali_via_https" {
-  count    = lookup(var.operations_instance_counts, "pentestportal", 0) > 0 ? 1 : 0
+  count    = lookup(var.operations_instance_counts, "pentestportal", 0) * lookup(var.operations_instance_counts, "kali", 0) > 0 ? 1 : 0
   provider = aws.provisionassessment
 
   security_group_id = aws_security_group.pentestportal.id
@@ -42,8 +47,11 @@ resource "aws_security_group_rule" "pentestportal_ingress_from_kali_via_https" {
 # Allow ingress from Kali instances via port 8080
 # For: Assessment team "development mode" access to pentest portal from
 # Kali instances
+#
+# NOTE: This rule will only be created if there is at least one Pentest Portal
+# instance and at least one Kali instance.
 resource "aws_security_group_rule" "pentestportal_ingress_from_kali_via_8080" {
-  count    = lookup(var.operations_instance_counts, "pentestportal", 0) > 0 ? 1 : 0
+  count    = lookup(var.operations_instance_counts, "pentestportal", 0) * lookup(var.operations_instance_counts, "kali", 0) > 0 ? 1 : 0
   provider = aws.provisionassessment
 
   security_group_id = aws_security_group.pentestportal.id
@@ -57,8 +65,8 @@ resource "aws_security_group_rule" "pentestportal_ingress_from_kali_via_8080" {
 # Allow egress to anywhere via HTTP and HTTPS
 # For: Pentest portal installation dependencies
 resource "aws_security_group_rule" "pentestportal_egress_to_anywhere_via_allowed_ports" {
+  for_each = toset([for port in ["80", "443"] : port if lookup(var.operations_instance_counts, "pentestportal", 0) > 0])
   provider = aws.provisionassessment
-  for_each = toset(["80", "443"])
 
   security_group_id = aws_security_group.pentestportal.id
   type              = "egress"

--- a/pentestportal_sg_rules.tf
+++ b/pentestportal_sg_rules.tf
@@ -65,7 +65,7 @@ resource "aws_security_group_rule" "pentestportal_ingress_from_kali_via_8080" {
 # Allow egress to anywhere via HTTP and HTTPS
 # For: Pentest portal installation dependencies
 resource "aws_security_group_rule" "pentestportal_egress_to_anywhere_via_allowed_ports" {
-  for_each = toset([for port in ["80", "443"] : port if lookup(var.operations_instance_counts, "pentestportal", 0) > 0])
+  for_each = lookup(var.operations_instance_counts, "pentestportal", 0) > 0 ? toset(["80", "443"]) : toset([])
   provider = aws.provisionassessment
 
   security_group_id = aws_security_group.pentestportal.id


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description

This PR adds conditions to various security group rules so that they are only created if the instance type(s) they apply to (e.g. `kali`, `debiandesktop`, `pentestportal`, etc.) exist in the environment.  

I also did a little splat syntax removal while I was in here, because I know how happy it makes @jsf9k.  

## 💭 Motivation and Context

While working in a test environment, I noticed that some security group rules were present even though the instances they applied to were not.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing

I modified the number of various instance types then executed `terraform plan` to validate that the corresponding security group rules were created/removed as expected.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
