### PR TITLE
Make all instances that mount the EFS volume depend on the EFS mount target(s)

### DIFF
--- a/debiandesktop_ec2.tf
+++ b/debiandesktop_ec2.tf
@@ -25,8 +25,11 @@ data "aws_ami" "debiandesktop" {
 
 # The "Debian desktop" EC2 instances
 resource "aws_instance" "debiandesktop" {
-  count    = lookup(var.operations_instance_counts, "debiandesktop", 0)
-  provider = aws.provisionassessment
+  count = lookup(var.operations_instance_counts, "debiandesktop", 0)
+  # These instances require the EFS mount target to be present in
+  # order to mount the EFS volume at boot time.
+  depends_on = [aws_efs_mount_target.target]
+  provider   = aws.provisionassessment
 
   ami                         = data.aws_ami.debiandesktop.id
   associate_public_ip_address = true

--- a/gophish_ec2.tf
+++ b/gophish_ec2.tf
@@ -25,8 +25,11 @@ data "aws_ami" "gophish" {
 
 # The GoPhish EC2 instances
 resource "aws_instance" "gophish" {
-  count    = lookup(var.operations_instance_counts, "gophish", 0)
-  provider = aws.provisionassessment
+  count = lookup(var.operations_instance_counts, "gophish", 0)
+  # These instances require the EFS mount target to be present in
+  # order to mount the EFS volume at boot time.
+  depends_on = [aws_efs_mount_target.target]
+  provider   = aws.provisionassessment
 
   ami                         = data.aws_ami.gophish.id
   associate_public_ip_address = true

--- a/kali_ec2.tf
+++ b/kali_ec2.tf
@@ -23,10 +23,13 @@ data "aws_ami" "kali" {
   most_recent = true
 }
 
-# The Kali EC2 instance
+# The Kali EC2 instances
 resource "aws_instance" "kali" {
-  count    = lookup(var.operations_instance_counts, "kali", 0)
-  provider = aws.provisionassessment
+  count = lookup(var.operations_instance_counts, "kali", 0)
+  # These instances require the EFS mount target to be present in
+  # order to mount the EFS volume at boot time.
+  depends_on = [aws_efs_mount_target.target]
+  provider   = aws.provisionassessment
 
   ami                         = data.aws_ami.kali.id
   associate_public_ip_address = true

--- a/pentestportal_ec2.tf
+++ b/pentestportal_ec2.tf
@@ -25,8 +25,11 @@ data "aws_ami" "docker" {
 
 # The pentest portal EC2 instances
 resource "aws_instance" "pentestportal" {
-  count    = lookup(var.operations_instance_counts, "pentestportal", 0)
-  provider = aws.provisionassessment
+  count = lookup(var.operations_instance_counts, "pentestportal", 0)
+  # These instances require the EFS mount target to be present in
+  # order to mount the EFS volume at boot time.
+  depends_on = [aws_efs_mount_target.target]
+  provider   = aws.provisionassessment
 
   ami                         = data.aws_ami.docker.id
   associate_public_ip_address = true

--- a/teamserver_ec2.tf
+++ b/teamserver_ec2.tf
@@ -25,8 +25,11 @@ data "aws_ami" "teamserver" {
 
 # The teamserver EC2 instances
 resource "aws_instance" "teamserver" {
-  count    = lookup(var.operations_instance_counts, "teamserver", 0)
-  provider = aws.provisionassessment
+  count = lookup(var.operations_instance_counts, "teamserver", 0)
+  # These instances require the EFS mount target to be present in
+  # order to mount the EFS volume at boot time.
+  depends_on = [aws_efs_mount_target.target]
+  provider   = aws.provisionassessment
 
   ami                         = data.aws_ami.teamserver.id
   associate_public_ip_address = true


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds a `depends_on = [aws_efs_mount.target.target]` key to all EC2 instances that mount the EFS volume.

## 💭 Motivation and Context ##

Issue #85 captures a few cases, particularly among the Pentest Portal instances, where the EFS volume was not mounted at boot.  Afterwards a simple `mount -a` command does successfully mount the EFS volume, the the issue was clearly not that the EC2 instances lacked the appropriate permissions.

I was eventually able to reproduce the problem.  I found that, when creating both the EFS mount target(s) and the EC2 instances, it was possible for the EFS mount target(s) to be created _after_ the EC2 instances that require it (them) to mount the EFS volume.  Adding a `depends_on = [aws_efs_mount.target.target]` key to all EC2 instances that mount the EFS volume ensures that the mount target(s) is (are) created _before_ such instances.

I am confident that this behavior was at the root of the bug reports we received, and therefore this pull request resolves #85.

## 🧪 Testing ##

As described above, I reproduced the error that was reported and then verified that the changes in this pull request corrected the error.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
