### PR TITLE
Rename two misnamed resources

### DIFF
--- a/route53.tf
+++ b/route53.tf
@@ -40,17 +40,18 @@ resource "aws_route53_zone" "private_subnet_reverse" {
   }
 }
 
-# Associate assessment VPC with Shared Services Route53 (private DNS) zone
-resource "aws_route53_vpc_association_authorization" "assessment_public" {
+# Associate assessment VPC with Shared Services Route53 (private DNS)
+# zone
+resource "aws_route53_vpc_association_authorization" "assessment_private" {
   provider = aws.dns_sharedservices
 
   vpc_id  = aws_vpc.assessment.id
   zone_id = data.terraform_remote_state.sharedservices_networking.outputs.private_zone.id
 }
 
-resource "aws_route53_zone_association" "assessment_public" {
+resource "aws_route53_zone_association" "assessment_private" {
   provider = aws.provisionassessment
 
-  vpc_id  = aws_route53_vpc_association_authorization.assessment_public.vpc_id
-  zone_id = aws_route53_vpc_association_authorization.assessment_public.zone_id
+  vpc_id  = aws_route53_vpc_association_authorization.assessment_private.vpc_id
+  zone_id = aws_route53_vpc_association_authorization.assessment_private.zone_id
 }


### PR DESCRIPTION
## 🗣 Description ##

This PR renames two Terraform resources.  The original names were incorrect/misleading.

## 💭 Motivation and Context ##

I was looking at this code to remind myself of how it worked.  The misnamed resources momentarily led me astray, so I thought it would be a good idea to go ahead and rename them.

## 🧪 Testing ##

I verified that this Terraform applies cleanly to env0 in our staging COOL environment.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
