### PR TITLE
Add a cloud-init shell script to ensure mounting of the EFS share

### DIFF
--- a/cloud-init/mount-efs-share.tpl.sh
+++ b/cloud-init/mount-efs-share.tpl.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+# This is a Terraform template file, and the mount_point variable is
+# passed in via the templatefile().
+#
+# shellcheck disable=SC2154
+until findmnt "${mount_point}"
+do
+    sleep 2
+    echo "Attempting to mount EFS share."
+    mount --all
+done

--- a/cloud-init/mount-efs-share.tpl.sh
+++ b/cloud-init/mount-efs-share.tpl.sh
@@ -11,6 +11,6 @@ set -o pipefail
 until findmnt "${mount_point}"
 do
     sleep 2
-    echo "Attempting to mount EFS share."
+    echo Attempting to mount EFS share at "${mount_point}".
     mount --all
 done

--- a/gophish_cloud_init.tf
+++ b/gophish_cloud_init.tf
@@ -12,6 +12,7 @@ data "cloudinit_config" "gophish_cloud_init_tasks" {
   # filenames will also be used as a filename in the scripts
   # directory.
 
+  # Create an fstab entry for the EFS share
   part {
     content = templatefile(
       "${path.module}/cloud-init/efs-mount.tpl.yml", {
@@ -21,6 +22,21 @@ data "cloudinit_config" "gophish_cloud_init_tasks" {
     })
     content_type = "text/cloud-config"
     filename     = "efs_mount.yml"
+    merge_type   = "list(append)+dict(recurse_array)+str()"
+  }
+
+  # This shell script loops until the EFS share is mounted.  We do
+  # make the instance depend on the EFS share in the Terraform code,
+  # but it is still possible for an instance to boot up without
+  # mounting the share.  See this issue comment for more details:
+  # https://github.com/cisagov/cool-assessment-terraform/issues/85#issuecomment-754052796
+  part {
+    content = templatefile(
+      "${path.module}/cloud-init/mount-efs-share.tpl.sh", {
+        mount_point = "/share"
+    })
+    content_type = "text/x-shellscript"
+    filename     = "mount-efs-share.sh"
     merge_type   = "list(append)+dict(recurse_array)+str()"
   }
 

--- a/kali_cloud_init.tf
+++ b/kali_cloud_init.tf
@@ -10,6 +10,7 @@ data "cloudinit_config" "kali_cloud_init_tasks" {
   # filenames will also be used as a filename in the scripts
   # directory.
 
+  # Create an fstab entry for the EFS share
   part {
     content = templatefile(
       "${path.module}/cloud-init/efs-mount.tpl.yml", {
@@ -19,6 +20,21 @@ data "cloudinit_config" "kali_cloud_init_tasks" {
     })
     content_type = "text/cloud-config"
     filename     = "efs_mount.yml"
+    merge_type   = "list(append)+dict(recurse_array)+str()"
+  }
+
+  # This shell script loops until the EFS share is mounted.  We do
+  # make the instance depend on the EFS share in the Terraform code,
+  # but it is still possible for an instance to boot up without
+  # mounting the share.  See this issue comment for more details:
+  # https://github.com/cisagov/cool-assessment-terraform/issues/85#issuecomment-754052796
+  part {
+    content = templatefile(
+      "${path.module}/cloud-init/mount-efs-share.tpl.sh", {
+        mount_point = "/share"
+    })
+    content_type = "text/x-shellscript"
+    filename     = "mount-efs-share.sh"
     merge_type   = "list(append)+dict(recurse_array)+str()"
   }
 }


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds a shell script to be run by [cloud-init](https://cloud-init.io/) to ensure mounting of the EFS share at boot.

## 💭 Motivation and Context ##

Even with the changes in commit 638f1824d588b0631048ba3437e72d882da1349c, it is apparently still possible for an instance to slip through the cracks and boot without mounting the EFS share.  I believe this is because Terraform has no way to distinguish between the "resource created" and "resource created and ready for use" states; hence, the share can be created but not become available for attachment until _after_ the instance has already booted up and attempted to automount the mounts listed in `/etc/fstab`.

This change should resolve #85.

## 🧪 Testing ##

I applied these changes to env0 in our staging COOL environment and verified that the EFS share was mounted by both Kali instances.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
