### PR TITLE
Use a t3 AWS instance type for Kali

### DIFF
--- a/kali_ec2.tf
+++ b/kali_ec2.tf
@@ -35,7 +35,7 @@ resource "aws_instance" "kali" {
   associate_public_ip_address = true
   availability_zone           = "${var.aws_region}${var.aws_availability_zone}"
   iam_instance_profile        = aws_iam_instance_profile.kali.name
-  instance_type               = "t2.xlarge"
+  instance_type               = "t3.xlarge"
   subnet_id                   = aws_subnet.operations.id
 
   root_block_device {


### PR DESCRIPTION
## 🗣 Description ##

This PR makes the change of deploying Kali instances on [t3 hardware](https://aws.amazon.com/ec2/instance-types/t3/).  Previously such instances were deployed on older [t2 hardware](https://aws.amazon.com/ec2/instance-types/t2/).

## 💭 Motivation and Context ##

The older t2 instances are being phased out in some availability zones, so there are more t3s available.

## 🧪 Testing ##

I successfully applied these changes to env0 in our staging COOL environment.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
