### PR TITLE
Remove the NAT gateway

### DIFF
--- a/guacamole_sg.tf
+++ b/guacamole_sg.tf
@@ -38,20 +38,6 @@ resource "aws_security_group_rule" "guacamole_egress_to_hosts_via_vnc" {
   to_port                  = 5901
 }
 
-# Allow egress anywhere via HTTPS
-#
-# For: Guacamole access to Docker Hub via the NAT gateway
-resource "aws_security_group_rule" "guacamole_egress_anywhere_via_https" {
-  provider = aws.provisionassessment
-
-  security_group_id = aws_security_group.guacamole.id
-  type              = "egress"
-  protocol          = "tcp"
-  cidr_blocks       = ["0.0.0.0/0"]
-  from_port         = 443
-  to_port           = 443
-}
-
 # Allow egress via HTTPS to any STS interface endpoint
 #
 # For: Guacamole assumes a role via STS.  This role allows Guacamole

--- a/operations_acl_rules.tf
+++ b/operations_acl_rules.tf
@@ -33,23 +33,6 @@ resource "aws_network_acl_rule" "operations_ingress_from_private_via_vnc" {
   to_port        = 5901
 }
 
-# Allow ingress from the private subnets via port 443.  This is
-# necessary so that the Guacamole instance can download the Docker
-# images used in the Docker composition via the NAT gateway.
-resource "aws_network_acl_rule" "operations_ingress_from_private_via_https" {
-  provider = aws.provisionassessment
-  for_each = toset(var.private_subnet_cidr_blocks)
-
-  network_acl_id = aws_network_acl.operations.id
-  egress         = false
-  protocol       = "tcp"
-  rule_number    = 104 + index(var.private_subnet_cidr_blocks, each.value)
-  rule_action    = "allow"
-  cidr_block     = aws_subnet.private[each.value].cidr_block
-  from_port      = 443
-  to_port        = 443
-}
-
 # Allow ingress from anywhere via the TCP ports specified in
 # var.operations_subnet_inbound_tcp_ports_allowed
 #
@@ -178,10 +161,6 @@ resource "aws_network_acl_rule" "operations_ingress_from_anywhere_via_icmp" {
 # Allow egress to anywhere via any protocol and port
 #
 # For: Assessment team operational use
-#
-# Note that this also covers the return traffic when the Guacamole
-# instance downloads the Docker images used in the Docker composition
-# via the NAT gateway in the operations subnet.
 resource "aws_network_acl_rule" "operations_egress_to_anywhere_via_any_port" {
   provider = aws.provisionassessment
 

--- a/private_acl_rules.tf
+++ b/private_acl_rules.tf
@@ -96,9 +96,6 @@ resource "aws_network_acl_rule" "private_egress_to_operations_via_ssh" {
 #
 # Note that this also covers ingress from the operations subnet via
 # TCP port 2049 for EFS.
-#
-# Note that this also allows the return traffic from any HTTPS
-# requests sent out via the NAT gateway in the operations subnet.
 resource "aws_network_acl_rule" "private_ingress_from_operations_via_ephemeral_ports" {
   provider = aws.provisionassessment
   for_each = toset(var.private_subnet_cidr_blocks)

--- a/private_routing.tf
+++ b/private_routing.tf
@@ -1,6 +1,5 @@
 #-------------------------------------------------------------------------------
-# Note that all these resources depend on the VPC, the NAT GWs, or
-# both, and hence on the
+# Note that all these resources depend on the VPC, and hence on the
 # aws_iam_role_policy_attachment.provisionassessment_policy_attachment
 # resource.
 # -------------------------------------------------------------------------------
@@ -18,8 +17,7 @@
 # route external traffic from each private subnet to the NAT gateway
 # in the public subnet that resides in the same AZ, and this would
 # obviously require separate routing tables.  However, in this case we
-# only create a single NAT gateway in the one operations subnet that
-# is shared by all private subnets.
+# create no NAT gateways.
 resource "aws_route_table" "private_route_table" {
   provider = aws.provisionassessment
 
@@ -42,16 +40,6 @@ resource "aws_vpc_endpoint_route_table_association" "s3_private" {
 
   route_table_id  = aws_route_table.private_route_table.id
   vpc_endpoint_id = aws_vpc_endpoint.s3.id
-}
-
-# Route all external (outside this VPC and outside the COOL) traffic
-# through the NAT gateway
-resource "aws_route" "external_private" {
-  provider = aws.provisionassessment
-
-  route_table_id         = aws_route_table.private_route_table.id
-  destination_cidr_block = "0.0.0.0/0"
-  nat_gateway_id         = aws_nat_gateway.nat_gw.id
 }
 
 # Associate the routing table with the subnets

--- a/subnets.tf
+++ b/subnets.tf
@@ -45,22 +45,3 @@ resource "aws_internet_gateway" "assessment" {
   vpc_id = aws_vpc.assessment.id
   tags   = var.tags
 }
-
-#-------------------------------------------------------------------------------
-# Create a NAT gateway for the private subnets.
-# -------------------------------------------------------------------------------
-resource "aws_eip" "nat_gw" {
-  provider = aws.provisionassessment
-
-  tags = var.tags
-  vpc  = true
-}
-
-resource "aws_nat_gateway" "nat_gw" {
-  provider = aws.provisionassessment
-
-  allocation_id = aws_eip.nat_gw.id
-  # Reminder: The NAT gateway lives in the operations subnet
-  subnet_id = aws_subnet.operations.id
-  tags      = var.tags
-}


### PR DESCRIPTION
## 🗣 Description ##

This pull request removes the NAT gateway and associated security group and ACL rules.

## 💭 Motivation and context ##

The NAT gateway is no longer needed after cisagov/ansible-role-guacamole#26 and cisagov/guacamole-packer#37 are merged.

See cisagov/cool-system#158 for more details.

## 🧪 Testing ##

I have deployed these changes (as well as those from cisagov/ansible-role-guacamole#26 and cisagov/guacamole-packer#37) to env0 in our COOL staging environment.  The Guacamole server continues to function as expected.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
