### PR TITLE
Pin the VPC flow logs module we are using

### DIFF
--- a/vpc_flow_logs.tf
+++ b/vpc_flow_logs.tf
@@ -3,6 +3,8 @@
 #-------------------------------------------------------------------------------
 module "vpc_flow_logs" {
   source = "trussworks/vpc-flow-logs/aws"
+  # Version 2.1.0 dropped support for TF 0.12
+  version = ">=2.0.0, <2.1.0"
   providers = {
     aws = aws.provisionassessment
   }


### PR DESCRIPTION
## 🗣 Description ##

This PR pins the version of [the VPC flow logs module we are using](https://registry.terraform.io/modules/trussworks/vpc-flow-logs/aws/latest).

## 💭 Motivation and context ##

Version 2.1.0 of the VPC flow logs module we are using dropped support for Terraform 0.12.

## 🧪 Testing ##

All `pre-commit` hooks pass.  The same change has already been applied to the Shared Services VPC of our staging COOL environment.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
