### PR TITLE
Ensure Nessus instance has access to STS and SSM endpoints before launch

### DIFF
--- a/nessus_ec2.tf
+++ b/nessus_ec2.tf
@@ -33,6 +33,15 @@ resource "aws_instance" "nessus" {
   count    = lookup(var.operations_instance_counts, "nessus", 0)
   provider = aws.provisionassessment
 
+  # When a Nessus instance starts up, it executes cloud-init/nessus-setup.sh,
+  # which requires access to the STS and SSM endpoints.  To ensure that access
+  # is available, we force dependencies on the security group rules that
+  # allow STS and SSM endpoint access from Nessus.
+  depends_on = [
+    aws_security_group_rule.ingress_from_nessus_to_sts_via_https,
+    aws_security_group_rule.ingress_from_nessus_to_ssm_via_https
+  ]
+
   ami                         = data.aws_ami.nessus.id
   associate_public_ip_address = true
   availability_zone           = "${var.aws_region}${var.aws_availability_zone}"


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
This PR adds two dependencies to the Nessus instance for the security group rules that allow access to the STS and SSM endpoints.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##
While redeploying one of our environments, I observed a failure of [our Nessus setup script](https://github.com/cisagov/cool-assessment-terraform/blob/develop/cloud-init/nessus-setup.sh):

```
Cloud-init v. 20.2 running 'modules:config' at Mon, 08 Feb 2021 19:51:54 +0000. Up 75.12 seconds.
Assuming role that can read Nessus-related SSM Parameter Store parameters

Could not connect to the endpoint URL: "https://sts.us-east-1.amazonaws.com/"
Reading Nessus-related parameters from SSM Parameter Store...

Could not connect to the endpoint URL: "https://ssm.us-east-1.amazonaws.com/"
WARNING: Could not read admin username from SSM!

Could not connect to the endpoint URL: "https://ssm.us-east-1.amazonaws.com/"
WARNING: Could not read admin password from SSM!
```

I believe this happened because Terraform launched the Nessus instance before it created the security group rules that allow access to the STS and SSM endpoints.  This PR attempts to correct that situation.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
I confirmed that `terraform apply` ran without error (no changes as a result of this PR), but other than that, I am just going to have to keep an eye out to see if this issue arises again and if so, do further investigation.

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
