### PR TITLE
Remove a duplicate IAM permission

### DIFF
--- a/provisionassessment_policy.tf
+++ b/provisionassessment_policy.tf
@@ -13,7 +13,6 @@ data "aws_iam_policy_document" "provisionassessment_policy_doc" {
       "ec2:AssociateTransitGatewayRouteTable",
       "ec2:AttachInternetGateway",
       "ec2:AuthorizeSecurityGroupEgress",
-      "ec2:AuthorizeSecurityGroupEgress",
       "ec2:AuthorizeSecurityGroupIngress",
       "ec2:CreateDhcpOptions",
       "ec2:CreateFlowLogs",


### PR DESCRIPTION
## 🗣 Description ##

This pull request removes a duplicated IAM permission from a policy.

## 💭 Motivation and context ##

I was looking at this policy as an example for how to do something, and I noticed this duplication.  I figured I may as well go ahead and make a quick PR to clean it up.

## 🧪 Testing ##

All `pre-commit` hooks pass.  I ran a `terraform apply` with these changes against env0 in our staging COOL environment and verified that they resulted in no resources being created, destroyed, or modified.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
