### PR TITLE
Bump up the size of the Debian Desktop instances

### DIFF
--- a/debiandesktop_ec2.tf
+++ b/debiandesktop_ec2.tf
@@ -35,7 +35,7 @@ resource "aws_instance" "debiandesktop" {
   associate_public_ip_address = true
   availability_zone           = "${var.aws_region}${var.aws_availability_zone}"
   iam_instance_profile        = aws_iam_instance_profile.debiandesktop.name
-  instance_type               = "t3.small"
+  instance_type               = "t3.medium"
   subnet_id                   = aws_subnet.operations.id
 
   root_block_device {


### PR DESCRIPTION
## 🗣 Description ##

This pull request bumps up the size of the Debian Desktop instance from `t3.small` to `t3.medium`.

## 💭 Motivation and context ##

@dav3r noticed that a Debian Desktop instance had locked up this morning.  Upon inspection of the kernel logs I saw that it had run out of memory.  I noticed that these instance types were only `t3.small`, which has a mere 2GB of RAM.  That's a bit thin on memory for running Linux with a desktop environment and a modern web browser, so I bumped the instance type up to a `t3.medium`.  These instance types have 4GB of RAM, which should suffice.

## 🧪 Testing ##

All `pre-commit` hooks pass.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
