### PR TITLE
Lock down the Instance Meta-Data Service (IMDS)

### DIFF
--- a/debiandesktop_ec2.tf
+++ b/debiandesktop_ec2.tf
@@ -37,24 +37,31 @@ resource "aws_instance" "debiandesktop" {
   iam_instance_profile        = aws_iam_instance_profile.debiandesktop.name
   instance_type               = "t3.medium"
   subnet_id                   = aws_subnet.operations.id
-
+  # AWS Instance Meta-Data Service (IMDS) options
+  metadata_options {
+    # Enable IMDS (this is the default value)
+    http_endpoint = "enabled"
+    # Restrict put responses from IMDS to a single hop (this is the
+    # default value).  This effectively disallows the retrieval of an
+    # IMDSv2 token via this machine from anywhere else.
+    http_put_response_hop_limit = 1
+    # Require IMDS tokens AKA require the use of IMDSv2
+    http_tokens = "required"
+  }
   root_block_device {
     volume_type           = "gp2"
     volume_size           = 128
     delete_on_termination = true
   }
-
   # We can use the same cloud-init code as the Kali instances, since
   # all it does is set up /etc/fstab to mount the EFS file share.
   user_data_base64 = data.cloudinit_config.kali_cloud_init_tasks.rendered
-
   vpc_security_group_ids = [
     aws_security_group.cloudwatch_and_ssm_agent.id,
     aws_security_group.debiandesktop.id,
     aws_security_group.efs_client.id,
     aws_security_group.guacamole_accessible.id,
   ]
-
   tags        = merge(var.tags, map("Name", format("DebianDesktop%d", count.index)))
   volume_tags = merge(var.tags, map("Name", format("DebianDesktop%d", count.index)))
 }

--- a/gophish_ec2.tf
+++ b/gophish_ec2.tf
@@ -37,15 +37,23 @@ resource "aws_instance" "gophish" {
   iam_instance_profile        = aws_iam_instance_profile.gophish.name
   instance_type               = "t3.small"
   subnet_id                   = aws_subnet.operations.id
-
+  # AWS Instance Meta-Data Service (IMDS) options
+  metadata_options {
+    # Enable IMDS (this is the default value)
+    http_endpoint = "enabled"
+    # Restrict put responses from IMDS to a single hop (this is the
+    # default value).  This effectively disallows the retrieval of an
+    # IMDSv2 token via this machine from anywhere else.
+    http_put_response_hop_limit = 1
+    # Require IMDS tokens AKA require the use of IMDSv2
+    http_tokens = "required"
+  }
   root_block_device {
     volume_type           = "gp2"
     volume_size           = 128
     delete_on_termination = true
   }
-
   user_data_base64 = data.cloudinit_config.gophish_cloud_init_tasks[count.index].rendered
-
   vpc_security_group_ids = [
     aws_security_group.cloudwatch_and_ssm_agent.id,
     aws_security_group.efs_client.id,
@@ -53,7 +61,6 @@ resource "aws_instance" "gophish" {
     aws_security_group.guacamole_accessible.id,
     aws_security_group.scanner.id,
   ]
-
   tags        = merge(var.tags, map("Name", format("GoPhish%d", count.index)))
   volume_tags = merge(var.tags, map("Name", format("GoPhish%d", count.index)))
 }

--- a/guacamole_ec2.tf
+++ b/guacamole_ec2.tf
@@ -46,20 +46,27 @@ resource "aws_instance" "guacamole" {
   iam_instance_profile = aws_iam_instance_profile.guacamole.name
   instance_type        = "t3.medium"
   subnet_id            = aws_subnet.private[var.private_subnet_cidr_blocks[0]].id
-
+  # AWS Instance Meta-Data Service (IMDS) options
+  metadata_options {
+    # Enable IMDS (this is the default value)
+    http_endpoint = "enabled"
+    # Restrict put responses from IMDS to a single hop (this is the
+    # default value).  This effectively disallows the retrieval of an
+    # IMDSv2 token via this machine from anywhere else.
+    http_put_response_hop_limit = 1
+    # Require IMDS tokens AKA require the use of IMDSv2
+    http_tokens = "required"
+  }
   root_block_device {
     volume_type           = "gp2"
     volume_size           = 8
     delete_on_termination = true
   }
-
   user_data_base64 = data.cloudinit_config.guacamole_cloud_init_tasks.rendered
-
   vpc_security_group_ids = [
     aws_security_group.cloudwatch_and_ssm_agent.id,
     aws_security_group.guacamole.id,
   ]
-
   tags        = merge(var.tags, map("Name", "Guacamole"))
   volume_tags = merge(var.tags, map("Name", "Guacamole"))
 }

--- a/nessus_ec2.tf
+++ b/nessus_ec2.tf
@@ -51,22 +51,29 @@ resource "aws_instance" "nessus" {
   iam_instance_profile        = aws_iam_instance_profile.nessus[0].name
   instance_type               = "m5.large"
   subnet_id                   = aws_subnet.operations.id
-
+  # AWS Instance Meta-Data Service (IMDS) options
+  metadata_options {
+    # Enable IMDS (this is the default value)
+    http_endpoint = "enabled"
+    # Restrict put responses from IMDS to a single hop (this is the
+    # default value).  This effectively disallows the retrieval of an
+    # IMDSv2 token via this machine from anywhere else.
+    http_put_response_hop_limit = 1
+    # Require IMDS tokens AKA require the use of IMDSv2
+    http_tokens = "required"
+  }
   root_block_device {
     volume_type           = "gp2"
     volume_size           = 128
     delete_on_termination = true
   }
-
   user_data_base64 = data.cloudinit_config.nessus_cloud_init_tasks[count.index].rendered
-
   vpc_security_group_ids = [
     aws_security_group.cloudwatch_and_ssm_agent.id,
     aws_security_group.guacamole_accessible.id,
     aws_security_group.nessus.id,
     aws_security_group.scanner.id,
   ]
-
   tags        = merge(var.tags, map("Name", format("Nessus%d", count.index)))
   volume_tags = merge(var.tags, map("Name", format("Nessus%d", count.index)))
 }

--- a/pentestportal_ec2.tf
+++ b/pentestportal_ec2.tf
@@ -37,24 +37,31 @@ resource "aws_instance" "pentestportal" {
   iam_instance_profile        = aws_iam_instance_profile.pentestportal.name
   instance_type               = "t3.small"
   subnet_id                   = aws_subnet.operations.id
-
+  # AWS Instance Meta-Data Service (IMDS) options
+  metadata_options {
+    # Enable IMDS (this is the default value)
+    http_endpoint = "enabled"
+    # Restrict put responses from IMDS to a single hop (this is the
+    # default value).  This effectively disallows the retrieval of an
+    # IMDSv2 token via this machine from anywhere else.
+    http_put_response_hop_limit = 1
+    # Require IMDS tokens AKA require the use of IMDSv2
+    http_tokens = "required"
+  }
   root_block_device {
     volume_type           = "gp2"
     volume_size           = 128
     delete_on_termination = true
   }
-
   # We can use the same cloud-init code as the Kali instances, since
   # all it does is set up /etc/fstab to mount the EFS file share.
   user_data_base64 = data.cloudinit_config.kali_cloud_init_tasks.rendered
-
   vpc_security_group_ids = [
     aws_security_group.cloudwatch_and_ssm_agent.id,
     aws_security_group.efs_client.id,
     aws_security_group.guacamole_accessible.id,
     aws_security_group.pentestportal.id,
   ]
-
   tags        = merge(var.tags, map("Name", format("PentestPortal%d", count.index + 1)))
   volume_tags = merge(var.tags, map("Name", format("PentestPortal%d", count.index + 1)))
 }

--- a/teamserver_ec2.tf
+++ b/teamserver_ec2.tf
@@ -37,17 +37,25 @@ resource "aws_instance" "teamserver" {
   iam_instance_profile        = aws_iam_instance_profile.teamserver.name
   instance_type               = "t3.medium"
   subnet_id                   = aws_subnet.operations.id
-
   root_block_device {
     volume_type           = "gp2"
     volume_size           = 128
     delete_on_termination = true
   }
-
+  # AWS Instance Meta-Data Service (IMDS) options
+  metadata_options {
+    # Enable IMDS (this is the default value)
+    http_endpoint = "enabled"
+    # Restrict put responses from IMDS to a single hop (this is the
+    # default value).  This effectively disallows the retrieval of an
+    # IMDSv2 token via this machine from anywhere else.
+    http_put_response_hop_limit = 1
+    # Require IMDS tokens AKA require the use of IMDSv2
+    http_tokens = "required"
+  }
   # We can use the same cloud-init code as the Kali instances, since
   # all it does is set up /etc/fstab to mount the EFS file share.
   user_data_base64 = data.cloudinit_config.kali_cloud_init_tasks.rendered
-
   vpc_security_group_ids = [
     aws_security_group.cloudwatch_and_ssm_agent.id,
     aws_security_group.efs_client.id,
@@ -55,7 +63,6 @@ resource "aws_instance" "teamserver" {
     aws_security_group.scanner.id,
     aws_security_group.teamserver.id,
   ]
-
   tags        = merge(var.tags, map("Name", format("Teamserver%d", count.index)))
   volume_tags = merge(var.tags, map("Name", format("Teamserver%d", count.index)))
 }


### PR DESCRIPTION
## 🗣 Description ##

This pull request:
* Explicitly enables IMDS (which is the default behavior)
* Requires the use of IMDSv2
* Restricts the retrieval of IMDSv2 tokens to the host (also the default behavior)

## 💭 Motivation and context ##

See cisagov/cool-system#174 and cisagov/cool-system#175.

## 🧪 Testing ##

All `pre-commit` hooks pass.

I built [a new Guacamole AMI](https://github.com/cisagov/guacamole-packer/pull/43) containing the changes from cisagov/ansible-role-freeipa-client#28 and was able to verify that it functioned as expected.  Later I noticed that [the OpenVPN AMI with similar changes](https://github.com/cisagov/openvpn-packer/pull/44) _did not_ function as expected, and I realized that the Guacamole AMI was only behaving because of cisagov/guacamole-packer#44.

I am currently to get a newer version of `python3-botocore` in Debian Stable or Stable Backports.  In the meantime the Guacamole AMI is working and I have a workaround for the OpenVPN AMI.  That workaround is to:
1. Deploy the OpenVPN instance
2. Manually [make the use of IMDSv2 optional via the AWS CLI](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html#configuring-IMDS-existing-instances)
3. Manually re-run the cloud-init scripts for the OpenVPN instance

Therefore I think it is safe and better to proceed with merging this PR, rather than to leave it dangling while I continue to work through the Debian Backports process. 

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
