### PR TITLE
Allow Teamserver instances to communicate with port 587 on Gophish instances

### DIFF
--- a/gophish_sg.tf
+++ b/gophish_sg.tf
@@ -12,6 +12,19 @@ resource "aws_security_group" "gophish" {
   )
 }
 
+# Allow ingress from Teamservers via port 1587 (Docker-published SMTP mail
+# submission) so mail can be sent via the mail server on Gophish instances
+resource "aws_security_group_rule" "ingress_from_teamserver_to_gophish_via_1587" {
+  provider = aws.provisionassessment
+
+  security_group_id        = aws_security_group.gophish.id
+  type                     = "ingress"
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.teamserver.id
+  from_port                = 1587
+  to_port                  = 1587
+}
+
 # Allow ingress from anywhere via the allowed ports
 resource "aws_security_group_rule" "ingress_from_anywhere_to_gophish_via_allowed_ports" {
   provider = aws.provisionassessment

--- a/gophish_sg.tf
+++ b/gophish_sg.tf
@@ -12,17 +12,17 @@ resource "aws_security_group" "gophish" {
   )
 }
 
-# Allow ingress from Teamservers via port 1587 (Docker-published SMTP mail
-# submission) so mail can be sent via the mail server on Gophish instances
-resource "aws_security_group_rule" "ingress_from_teamserver_to_gophish_via_1587" {
+# Allow ingress from Teamserver instances via port 587 (SMTP mail submission)
+# so mail can be sent via the mail server on Gophish instances
+resource "aws_security_group_rule" "ingress_from_teamserver_to_gophish_via_smtp" {
   provider = aws.provisionassessment
 
   security_group_id        = aws_security_group.gophish.id
   type                     = "ingress"
   protocol                 = "tcp"
   source_security_group_id = aws_security_group.teamserver.id
-  from_port                = 1587
-  to_port                  = 1587
+  from_port                = 587
+  to_port                  = 587
 }
 
 # Allow ingress from anywhere via the allowed ports

--- a/teamserver_sg.tf
+++ b/teamserver_sg.tf
@@ -12,17 +12,17 @@ resource "aws_security_group" "teamserver" {
   )
 }
 
-# Allow egress via port 1587 (Docker-published SMTP mail submission) to
-# Gophish instances so that mail can be sent out via its mail server
-resource "aws_security_group_rule" "teamserver_egress_to_gophish_via_1587" {
+# Allow egress via port 587 (SMTP mail submission) to Gophish instances
+# so that mail can be sent out via its mail server
+resource "aws_security_group_rule" "teamserver_egress_to_gophish_via_587" {
   provider = aws.provisionassessment
 
   security_group_id        = aws_security_group.teamserver.id
   type                     = "egress"
   protocol                 = "tcp"
   source_security_group_id = aws_security_group.gophish.id
-  from_port                = 1587
-  to_port                  = 1587
+  from_port                = 587
+  to_port                  = 587
 }
 
 # Allow ingress from Kali instances via ports 993 and 50050 (IMAP over

--- a/teamserver_sg.tf
+++ b/teamserver_sg.tf
@@ -12,6 +12,19 @@ resource "aws_security_group" "teamserver" {
   )
 }
 
+# Allow egress via port 1587 (Docker-published SMTP mail submission) to
+# Gophish instances so that mail can be sent out via its mail server
+resource "aws_security_group_rule" "teamserver_egress_to_gophish_via_1587" {
+  provider = aws.provisionassessment
+
+  security_group_id        = aws_security_group.teamserver.id
+  type                     = "egress"
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.gophish.id
+  from_port                = 1587
+  to_port                  = 1587
+}
+
 # Allow ingress from Kali instances via ports 993 and 50050 (IMAP over
 # TLS/SSL and Cobalt Strike, respectively)
 resource "aws_security_group_rule" "teamserver_ingress_from_kali_via_imaps_and_cs" {


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR updates the security group rules to allow communication from Teamserver instances to Gophish instances on port 587.
 
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This change will enable mail to be sent from Cobalt Strike (on the Teamservers) via the SMTP mail-submission port published by the Postfix Docker container (587) on the Gophish instances.

Resolves #111 and is part of the work required for https://github.com/cisagov/cool-system/issues/90.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

After applying these changes in my test environment, I used `netcat` to confirm that I was able to communicate from a Teamserver instance to port 587 on a Gophish instance.

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
