### PR TITLE
Enable Thunderbird email account autoconfiguration

### DIFF
--- a/cloud-init/map-hostname-to-localhost.tpl.sh
+++ b/cloud-init/map-hostname-to-localhost.tpl.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+# This script checks a hosts file to see if it includes a mapping between
+# a given hostname and the local host (127.0.0.1).  If that mapping does not
+# exist, it is created.
+
+# Input variables:
+# hostname - The hostname to map to 127.0.0.1.
+# hosts_file - The full path to the hosts file to be updated (if necessary).
+
+# This is a Terraform template file, and the hostname and hosts_file variables
+# are passed in via templatefile().
+#
+# Since this script is processed by Terraform's templatefile() function
+# before it is deployed via cloud-init, shell script variables that
+# that would normally be referenced as
+# <dollar-sign><left-curly-brace>var_name<right-curly-brace> are escaped
+# via <dollar-sign><dollar-sign><left-curly-brace>var_name<right-curly-brace>.
+set -o nounset
+set -o errexit
+set -o pipefail
+
+# Put Terraform-supplied hostname in a shell variable so we can use parameter
+# expansion to create the escaped hostname.
+hostname="${hostname}"
+
+# Escape periods in hostname
+# e.g. example.com -> example\.com
+#
+# SC2034 ("escaped_hostname appears unused"): escaped_hostname is used in
+# the grep command below.
+# shellcheck disable=SC2034
+escaped_hostname="$${hostname//\./\\.}"
+
+# Check whether hostname is already mapped to 127.0.0.1 in the hosts file
+# We temporarily disable errexit so that our script won't terminate in the
+# case where our grep command fails to find anything.
+set +o errexit
+
+# beautysh (pre-commit hook) doesn't handle the following grep correctly, so
+# we have to temporarily turn off the formatting.
+# @formatter:off
+# The hosts_file variable is passed in via Terraform templatefile().
+# shellcheck disable=SC2154
+grep --quiet --ignore-case "^127\.0\.0\.1\s$${escaped_hostname}\s*$" "${hosts_file}"
+# @formatter:on
+grep_rc="$?"
+set -o errexit
+
+if [[ "$grep_rc" -ne 0 ]]
+then
+  # Add the mapping to the hosts file
+  echo -e "\n127.0.0.1 ${hostname}" >> "${hosts_file}"
+else
+  echo "No changes: ${hostname} already mapped to 127.0.0.1 in ${hosts_file}"
+fi

--- a/cloud-init/map-hostname-to-localhost.tpl.sh
+++ b/cloud-init/map-hostname-to-localhost.tpl.sh
@@ -39,6 +39,7 @@ set +o errexit
 
 # beautysh (pre-commit hook) doesn't handle the following grep correctly, so
 # we have to temporarily turn off the formatting.
+# Issue logged at: https://github.com/lovesegfault/beautysh/issues/86
 # @formatter:off
 # The hosts_file variable is passed in via Terraform templatefile().
 # shellcheck disable=SC2154

--- a/cloud-init/write-thunderbird-email-autoconfig.tpl.yml
+++ b/cloud-init/write-thunderbird-email-autoconfig.tpl.yml
@@ -1,0 +1,31 @@
+---
+# Write Thunderbird file that enables autoconfiguration of email accounts
+# from the email-sending domain for this assessment.  For details, see:
+# https://developer.mozilla.org/en-US/docs/Mozilla/Thunderbird/Autoconfiguration
+write_files:
+  - path: "/usr/lib/thunderbird/isp/${email_sending_domain}.xml"
+    permissions: "0644"
+    owner: root:root
+    content: |
+      <?xml version="1.0"?>
+      <clientConfig version="1.1">
+        <emailProvider id="${email_sending_domain}">
+          <domain>${email_sending_domain}</domain>
+          <displayName>${email_sending_domain}</displayName>
+          <displayShortName>${email_sending_domain}</displayShortName>
+          <incomingServer type="imap">
+            <hostname>${email_sending_domain}</hostname>
+            <port>993</port>
+            <socketType>SSL</socketType>
+            <authentication>password-cleartext</authentication>
+            <username>%EMAILLOCALPART%</username>
+          </incomingServer>
+          <outgoingServer type="smtp">
+            <hostname>${email_sending_domain}</hostname>
+            <port>587</port>
+            <socketType>STARTTLS</socketType>
+            <authentication>password-cleartext</authentication>
+            <username>%EMAILLOCALPART%</username>
+          </outgoingServer>
+        </emailProvider>
+      </clientConfig>

--- a/gophish_cloud_init.tf
+++ b/gophish_cloud_init.tf
@@ -139,4 +139,31 @@ data "cloudinit_config" "gophish_cloud_init_tasks" {
     filename     = "postfix-setup.yml"
     merge_type   = "list(append)+dict(recurse_array)+str()"
   }
+
+  # Configure Thunderbird to autoconfigure email accounts from this
+  # assessment's email-sending domain.
+  part {
+    content = templatefile(
+      "${path.module}/cloud-init/write-thunderbird-email-autoconfig.tpl.yml", {
+        email_sending_domain = var.email_sending_domain
+    })
+    content_type = "text/cloud-config"
+    filename     = "write-thunderbird-email-autoconfig.yml"
+    merge_type   = "list(append)+dict(recurse_array)+str()"
+  }
+
+  # Ensure email-sending domain is mapped to 127.0.0.1 in /etc/hosts.
+  # Note: Even though /etc/hosts on this instance is managed by cloud-init
+  # in /etc/cloud/templates/hosts.debian.tmpl, we can safely modify
+  # /etc/hosts here because our change will be applied at every startup,
+  # after the earlier cloud-init code applies hosts.debian.tmpl.
+  part {
+    content = templatefile(
+      "${path.module}/cloud-init/map-hostname-to-localhost.tpl.sh", {
+        hostname   = var.email_sending_domain
+        hosts_file = "/etc/hosts"
+    })
+    content_type = "text/x-shellscript"
+    filename     = "map-hostname-to-localhost.sh"
+  }
 }


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR makes two changes to the Gophish instance(s) in order to enable simple, seamless setup of email accounts in Thunderbird for the specified `var.email_sending_domain`:
* Deploy a [Thunderbird autoconfiguration file](https://developer.mozilla.org/en-US/docs/Mozilla/Thunderbird/Autoconfiguration) to the appropriate location
* Add a line to `/etc/hosts` mapping the email sending domain to the local host IP; this is done to avoid certificate errors when setting up the email accounts in Thunderbird

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

One of the assessment team requirements in https://github.com/cisagov/cool-system/issues/90 (documented in #124) is to set up Thunderbird so that email accounts can easily be setup and automatically configured, so this PR satisfies that requirement.

Resolves #124.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

To test this, I applied these changes in a Staging environment (with a test email-sending domain; let's call it `myemailsendingdomain.gov`) and verified all of the following:
- [x] `/usr/lib/thunderbird/isp/myemailsendingdomain.gov.xml` was deployed at instance startup
- [x] `/etc/hosts` contained an entry like `127.0.0.1 myemailsendingdomain.gov`
- [x] When using the Thunderbird "new email account" wizard to create accounts for `myemailsendingdomain.gov`, new accounts could be added without any errors and with the correct SMTP/IMAP configuration
- [x] Emails could be sent using the new account in Thunderbird
- [x] Emails sent from the new account could be viewed in Thunderbird via IMAPS

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
