### PR TITLE
Upgrade the teamserver instance type

### DIFF
--- a/teamserver_ec2.tf
+++ b/teamserver_ec2.tf
@@ -48,7 +48,7 @@ resource "aws_instance" "teamserver" {
   associate_public_ip_address = true
   availability_zone           = "${var.aws_region}${var.aws_availability_zone}"
   iam_instance_profile        = aws_iam_instance_profile.teamserver.name
-  instance_type               = "t3.medium"
+  instance_type               = "t3.large"
   subnet_id                   = aws_subnet.operations.id
   root_block_device {
     volume_type           = "gp2"


### PR DESCRIPTION
## 🗣 Description ##

This pull request upgrades the teamserver instance type from `t3.medium` (4GB RAM) to `t3.large` (8GB RAM).

## 💭 Motivation and context ##

PCA folks are reporting that they are running out of memory when starting Cobalt Strike.  Resolves cisagov/cool-system#205.

## 🧪 Testing ##

All `pre-commit` hooks and GitHub Actions workflows pass.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
