### PR TITLE
Support Assessor Portal instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ the COOL environment.
 | Name | Type |
 |------|------|
 | [aws_default_route_table.operations](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_route_table) | resource |
+| [aws_ebs_volume.assessorportal_docker](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ebs_volume) | resource |
 | [aws_ebs_volume.gophish_docker](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ebs_volume) | resource |
 | [aws_ec2_transit_gateway_route.assessment_route](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_route) | resource |
 | [aws_ec2_transit_gateway_route_table_association.association](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_route_table_association) | resource |
@@ -111,6 +112,7 @@ the COOL environment.
 | [aws_eip_association.gophish](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip_association) | resource |
 | [aws_eip_association.pentestportal](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip_association) | resource |
 | [aws_eip_association.teamserver](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip_association) | resource |
+| [aws_iam_instance_profile.assessorportal](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
 | [aws_iam_instance_profile.debiandesktop](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
 | [aws_iam_instance_profile.gophish](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
 | [aws_iam_instance_profile.guacamole](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
@@ -123,6 +125,7 @@ the COOL environment.
 | [aws_iam_policy.provisionassessment_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.ssmsession_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.vnc_parameterstorereadonly_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.assessorportal_instance_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.debiandesktop_instance_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.gophish_instance_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.guacamole_instance_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
@@ -133,9 +136,11 @@ the COOL environment.
 | [aws_iam_role.ssmsession_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.teamserver_instance_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.vnc_parameterstorereadonly_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.gophish_assume_delegated_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.guacamole_assume_delegated_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.nessus_assume_delegated_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.teamserver_assume_delegated_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy_attachment.cloudwatch_agent_policy_attachment_assessorportal](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.cloudwatch_agent_policy_attachment_debiandesktop](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.cloudwatch_agent_policy_attachment_gophish](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.cloudwatch_agent_policy_attachment_guacamole](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
@@ -143,6 +148,7 @@ the COOL environment.
 | [aws_iam_role_policy_attachment.cloudwatch_agent_policy_attachment_nessus](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.cloudwatch_agent_policy_attachment_pentestportal](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.cloudwatch_agent_policy_attachment_teamserver](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.efs_mount_policy_attachment_assessorportal](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.efs_mount_policy_attachment_debiandesktop](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.efs_mount_policy_attachment_gophish](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.efs_mount_policy_attachment_kali](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
@@ -150,6 +156,7 @@ the COOL environment.
 | [aws_iam_role_policy_attachment.efs_mount_policy_attachment_teamserver](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.nessus_parameterstorereadonly_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.provisionassessment_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.ssm_agent_policy_attachment_assessorportal](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.ssm_agent_policy_attachment_debiandesktop](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.ssm_agent_policy_attachment_gophics](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.ssm_agent_policy_attachment_guacamole](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
@@ -159,6 +166,7 @@ the COOL environment.
 | [aws_iam_role_policy_attachment.ssm_agent_policy_attachment_teamserver](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.ssmsession_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.vnc_parameterstorereadonly_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_instance.assessorportal](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
 | [aws_instance.debiandesktop](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
 | [aws_instance.gophish](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
 | [aws_instance.guacamole](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
@@ -193,6 +201,7 @@ the COOL environment.
 | [aws_route.cool_operations](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
 | [aws_route.cool_private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
 | [aws_route.external_operations](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
+| [aws_route53_record.assessorportal_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.debiandesktop_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.gophish_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.guacamole_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
@@ -207,6 +216,7 @@ the COOL environment.
 | [aws_route53_zone_association.assessment_private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone_association) | resource |
 | [aws_route_table.private_route_table](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |
 | [aws_route_table_association.private_route_table_associations](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
+| [aws_security_group.assessorportal](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.cloudwatch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.cloudwatch_and_ssm_agent](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.debiandesktop](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
@@ -226,14 +236,18 @@ the COOL environment.
 | [aws_security_group_rule.agent_egress_to_ssm_via_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.allow_nfs_inbound](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.allow_nfs_outbound](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.assessorportal_egress_to_anywhere_via_http_and_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.debiandesktop_egress_to_anywhere_via_http_and_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.debiandesktop_egress_to_nessus_via_web_ui](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.gophish_egress_to_s3_via_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.gophish_egress_to_sts_via_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.guacamole_egress_to_cool_via_ipa_ports](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.guacamole_egress_to_hosts_via_ssh](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.guacamole_egress_to_hosts_via_vnc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.guacamole_egress_to_s3_via_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.guacamole_egress_to_sts_via_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.guacamole_ingress_from_trusted_via_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.ingress_from_anywhere_to_assessorportal_via_allowed_ports](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ingress_from_anywhere_to_debiandesktop_via_allowed_ports](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ingress_from_anywhere_to_gophish_via_allowed_ports](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ingress_from_anywhere_to_kali_via_allowed_ports](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
@@ -244,6 +258,7 @@ the COOL environment.
 | [aws_security_group_rule.ingress_from_debiandesktop_to_ssm_via_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ingress_from_gophish_to_cloudwatch_via_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ingress_from_gophish_to_ssm_via_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.ingress_from_gophish_to_sts_via_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ingress_from_guacamole_to_cloudwatch_via_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ingress_from_guacamole_to_ssm_via_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ingress_from_guacamole_to_sts_via_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
@@ -275,6 +290,7 @@ the COOL environment.
 | [aws_security_group_rule.teamserver_ingress_from_kali_via_imaps_and_cs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_subnet.operations](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_subnet.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
+| [aws_volume_attachment.assessorportal_docker](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/volume_attachment) | resource |
 | [aws_volume_attachment.gophish_docker](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/volume_attachment) | resource |
 | [aws_vpc.assessment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) | resource |
 | [aws_vpc_dhcp_options.assessment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_dhcp_options) | resource |
@@ -299,6 +315,7 @@ the COOL environment.
 | [aws_vpc_endpoint_subnet_association.ssmmessages](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint_subnet_association) | resource |
 | [aws_vpc_endpoint_subnet_association.sts](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint_subnet_association) | resource |
 | [null_resource.break_association_with_default_route_table](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [aws_ami.assessorportal](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_ami.debiandesktop](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_ami.docker](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_ami.gophish](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
@@ -311,6 +328,7 @@ the COOL environment.
 | [aws_default_tags.assessment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/default_tags) | data source |
 | [aws_iam_policy_document.ec2_service_assume_role_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.efs_mount_policy_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.gophish_assume_delegated_role_policy_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.guacamole_assume_delegated_role_policy_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.nessus_assume_delegated_role_policy_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.nessus_assume_role_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -322,6 +340,7 @@ the COOL environment.
 | [aws_iam_policy_document.vnc_assume_role_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.vnc_parameterstorereadonly_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_organizations_organization.cool](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/organizations_organization) | data source |
+| [cloudinit_config.assessorportal_cloud_init_tasks](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs/data-sources/config) | data source |
 | [cloudinit_config.gophish_cloud_init_tasks](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs/data-sources/config) | data source |
 | [cloudinit_config.guacamole_cloud_init_tasks](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs/data-sources/config) | data source |
 | [cloudinit_config.kali_cloud_init_tasks](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs/data-sources/config) | data source |
@@ -347,9 +366,9 @@ the COOL environment.
 | dns\_ttl | The TTL value to use for Route53 DNS records (e.g. 86400).  A smaller value may be useful when the DNS records are changing often, for example when testing. | `number` | `60` | no |
 | email\_sending\_domain | The domain to send emails from within the assessment environment (e.g. "example.com"). | `string` | `"example.com"` | no |
 | guac\_connection\_setup\_path | The full path to the dbinit directory where initialization files must be stored in order to work properly. (e.g. "/var/guacamole/dbinit") | `string` | `"/var/guacamole/dbinit"` | no |
-| inbound\_ports\_allowed | A map specifying the ports allowed inbound (from anywhere) to the various instance types (e.g. {"kali": [{"protocol": "tcp", "from\_port": 8000, "to\_port": 8999}]}).  The currently-supported keys are: "debiandesktop", "gophish", "kali", "nessus", "pentestportal", and "teamserver". | `map(list(object({ protocol = string, from\_port = number, to\_port = number })))` | `{"debiandesktop": [], "gophish": [{"from\_port": 25, "protocol": "tcp", "to\_port": 25}, {"from\_port": 80, "protocol": "tcp", "to\_port": 80},{"from\_port": 443, "protocol": "tcp", "to\_port": 443}, {"from\_port": 587, "protocol": "tcp", "to\_port": 587}], "kali": [{"from\_port": 8000, "protocol": "tcp", "to\_port": 8999}], "nessus": [], "pentestportal": [], "teamserver": [{"from\_port": 25, "protocol": "tcp", "to\_port": 25}, {"from\_port": 53, "protocol": "tcp", "to\_port": 53}, {"from\_port": 80, "protocol": "tcp", "to\_port": 80}, {"from\_port": 443, "protocol": "tcp", "to\_port": 443}, {"from\_port": 587, "protocol": "tcp", "to\_port": 587}, {"from\_port": 53, "protocol": "udp", "to\_port": 53}, {"from\_port": 8080, "protocol": "udp", "to\_port": 8080}, {"from\_port": 8000, "protocol": "tcp", "to\_port": 8999}]}` | no |
+| inbound\_ports\_allowed | A map specifying the ports allowed inbound (from anywhere) to the various instance types (e.g. {"kali": [{"protocol": "tcp", "from\_port": 8000, "to\_port": 8999}]}).  The currently-supported keys are: "assessorportal", "debiandesktop", "gophish", "kali", "nessus", "pentestportal", and "teamserver". | `map(list(object({ protocol = string, from_port = number, to_port = number })))` | ```{ "assessorportal": [], "debiandesktop": [], "gophish": [ { "from_port": 25, "protocol": "tcp", "to_port": 25 }, { "from_port": 80, "protocol": "tcp", "to_port": 80 }, { "from_port": 443, "protocol": "tcp", "to_port": 443 }, { "from_port": 587, "protocol": "tcp", "to_port": 587 } ], "kali": [ { "from_port": 8000, "protocol": "tcp", "to_port": 8999 } ], "nessus": [], "pentestportal": [], "teamserver": [ { "from_port": 25, "protocol": "tcp", "to_port": 25 }, { "from_port": 53, "protocol": "tcp", "to_port": 53 }, { "from_port": 80, "protocol": "tcp", "to_port": 80 }, { "from_port": 443, "protocol": "tcp", "to_port": 443 }, { "from_port": 587, "protocol": "tcp", "to_port": 587 }, { "from_port": 53, "protocol": "udp", "to_port": 53 }, { "from_port": 8080, "protocol": "udp", "to_port": 8080 }, { "from_port": 8000, "protocol": "tcp", "to_port": 8999 } ] }``` | no |
 | nessus\_activation\_codes | The list of Nessus activation codes (e.g. ["AAAA-BBBB-CCCC-DDDD"]). The number of codes in this list should match the number of Nessus instances defined in operations\_instance\_counts. | `list(string)` | `[]` | no |
-| operations\_instance\_counts | A map specifying how many instances of each type should be created in the operations subnet (e.g. { "kali": 1 }).  The currently-supported instance keys are: ["debiandesktop", "gophish", "kali", "nessus", "pentestportal", "teamserver"]. | `map(number)` | `{"kali": 1}` | no |
+| operations\_instance\_counts | A map specifying how many instances of each type should be created in the operations subnet (e.g. { "kali": 1 }).  The currently-supported instance keys are: ["assessorportal", "debiandesktop", "gophish", "kali", "nessus", "pentestportal", "teamserver"]. | `map(number)` | ```{ "kali": 1 }``` | no |
 | operations\_subnet\_cidr\_block | The operations subnet CIDR block for this assessment (e.g. "10.10.0.0/24"). | `string` | n/a | yes |
 | private\_domain | The local domain to use for this assessment (e.g. "env0"). If not provided, `local.private_domain` will be set to the base of the assessment account name.  For example, if the account name is "env0 (Staging)", `local.private_domain` will default to "env0".  Note that `local.private_domain` should be used in place of `var.private_domain` throughout this project. | `string` | `""` | no |
 | private\_subnet\_cidr\_blocks | The list of private subnet CIDR blocks for this assessment (e.g. ["10.10.1.0/24", "10.10.2.0/24"]). | `list(string)` | n/a | yes |

--- a/assessorportal_cloud_init.tf
+++ b/assessorportal_cloud_init.tf
@@ -1,0 +1,88 @@
+# cloud-init commands for configuring Assessor Portal instances
+
+data "cloudinit_config" "assessorportal_cloud_init_tasks" {
+  count = lookup(var.operations_instance_counts, "assessorportal", 0)
+
+  gzip          = true
+  base64_encode = true
+
+  # Note: The filename parameters in each part below are only used to
+  # name the mime-parts of the user-data.  They do not affect the
+  # final name for the templates. For any x-shellscript parts, the
+  # filenames will also be used as a filename in the scripts
+  # directory.
+
+  # Create an fstab entry for the EFS share
+  part {
+    content = templatefile(
+      "${path.module}/cloud-init/efs-mount.tpl.yml", {
+        # Just mount the EFS mount target in the first private subnet
+        efs_id      = aws_efs_mount_target.target[var.private_subnet_cidr_blocks[0]].file_system_id
+        mount_point = "/share"
+    })
+    content_type = "text/cloud-config"
+    filename     = "efs_mount.yml"
+    merge_type   = "list(append)+dict(recurse_array)+str()"
+  }
+
+  # This shell script loops until the EFS share is mounted.  We do
+  # make the instance depend on the EFS share in the Terraform code,
+  # but it is still possible for an instance to boot up without
+  # mounting the share.  See this issue comment for more details:
+  # https://github.com/cisagov/cool-assessment-terraform/issues/85#issuecomment-754052796
+  part {
+    content = templatefile(
+      "${path.module}/cloud-init/mount-efs-share.tpl.sh", {
+        mount_point = "/share"
+    })
+    content_type = "text/x-shellscript"
+    filename     = "mount-efs-share.sh"
+  }
+
+  # Create the JSON file used to configure Docker daemon.  This allows us
+  # to tell Docker to store volume data on our persistent
+  # EBS Docker data volume (created below).
+  part {
+    content = templatefile(
+      "${path.module}/cloud-init/write-docker-daemon-json.tpl.yml", {
+        docker_data_root_dir = local.docker_volume_mount_point
+    })
+    content_type = "text/cloud-config"
+    filename     = "write-docker-daemon-json.yml"
+    merge_type   = "list(append)+dict(recurse_array)+str()"
+  }
+
+  # Prepare and mount EBS volume to hold Docker data-root data.
+  # Note that this script and the next one must take place in a certain order,
+  # so we prepend numbers to the script names to force that to that happen.
+  #
+  # Here is where the user scripts are called by cloud-init:
+  # https://github.com/canonical/cloud-init/blob/master/cloudinit/config/cc_scripts_user.py#L45
+  #
+  # And here is where you can see how cloud-init sorts the scripts:
+  # https://github.com/canonical/cloud-init/blob/master/cloudinit/subp.py#L373
+  part {
+    content = templatefile(
+      "${path.module}/cloud-init/ebs-disk-setup.tpl.sh", {
+        device_name   = local.docker_ebs_device_name
+        fs_type       = "ext4"
+        label         = "docker_data"
+        mount_options = "defaults"
+        mount_point   = local.docker_volume_mount_point
+        num_disks     = 2
+    })
+    content_type = "text/x-shellscript"
+    filename     = "01-ebs-disk-setup.sh"
+  }
+
+  # Copy Docker data from default directory to new data-root directory.
+  part {
+    content = templatefile(
+      "${path.module}/cloud-init/copy-docker-data-to-new-root-dir.tpl.sh", {
+        mount_point       = local.docker_volume_mount_point
+        new_data_root_dir = local.docker_volume_mount_point
+    })
+    content_type = "text/x-shellscript"
+    filename     = "02-copy-docker-data-to-new-root-dir.sh"
+  }
+}

--- a/assessorportal_ec2.tf
+++ b/assessorportal_ec2.tf
@@ -1,0 +1,101 @@
+# The Assessor Portal AMI
+data "aws_ami" "assessorportal" {
+  provider = aws.provisionassessment
+
+  filter {
+    name = "name"
+    values = [
+      "assessor-portal-hvm-*-x86_64-ebs"
+    ]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+
+  owners      = [local.images_account_id]
+  most_recent = true
+}
+
+# The Assessor Portal EC2 instances
+resource "aws_instance" "assessorportal" {
+  count = lookup(var.operations_instance_counts, "assessorportal", 0)
+  # These instances require the EFS mount target to be present in
+  # order to mount the EFS volume at boot time.
+  depends_on = [aws_efs_mount_target.target]
+  provider   = aws.provisionassessment
+
+  ami                         = data.aws_ami.assessorportal.id
+  associate_public_ip_address = true
+  availability_zone           = "${var.aws_region}${var.aws_availability_zone}"
+  iam_instance_profile        = aws_iam_instance_profile.assessorportal.name
+  instance_type               = "t3.medium"
+  subnet_id                   = aws_subnet.operations.id
+  # AWS Instance Meta-Data Service (IMDS) options
+  metadata_options {
+    # Enable IMDS (this is the default value)
+    http_endpoint = "enabled"
+    # Restrict put responses from IMDS to a single hop (this is the
+    # default value).  This effectively disallows the retrieval of an
+    # IMDSv2 token via this machine from anywhere else.
+    http_put_response_hop_limit = 1
+    # Require IMDS tokens AKA require the use of IMDSv2
+    http_tokens = "required"
+  }
+  root_block_device {
+    volume_type           = "gp2"
+    volume_size           = 128
+    delete_on_termination = true
+  }
+  user_data_base64 = data.cloudinit_config.assessorportal_cloud_init_tasks[count.index].rendered
+  vpc_security_group_ids = [
+    aws_security_group.cloudwatch_and_ssm_agent.id,
+    aws_security_group.assessorportal.id,
+    aws_security_group.efs_client.id,
+    aws_security_group.guacamole_accessible.id,
+  ]
+  tags = {
+    Name = format("AssessorPortal%d", count.index)
+  }
+  # volume_tags does not yet inherit the default tags from the
+  # provider.  See hashicorp/terraform-provider-aws#19188 for more
+  # details.
+  volume_tags = merge(data.aws_default_tags.assessment.tags, {
+    Name = format("AssessorPortal%d", count.index)
+  })
+}
+
+# The EBS volume for each Assessor Portal instance; it is used to persist
+# Docker volume data across instance restarts and redeployments.  Note that
+# Docker data cannot be stored on the existing EFS volume because EFS is not
+# supported as a backing file system for Docker:
+# https://docs.docker.com/storage/storagedriver/select-storage-driver/#supported-backing-filesystems
+resource "aws_ebs_volume" "assessorportal_docker" {
+  count    = lookup(var.operations_instance_counts, "assessorportal", 0)
+  provider = aws.provisionassessment
+
+  availability_zone = "${var.aws_region}${var.aws_availability_zone}"
+  encrypted         = true
+  size              = 16
+  type              = "gp2"
+
+  tags = {
+    Name = format("AssessorPortal%d Docker", count.index)
+  }
+}
+
+# Attach EBS volume to Assessor Portal instance
+resource "aws_volume_attachment" "assessorportal_docker" {
+  count    = lookup(var.operations_instance_counts, "assessorportal", 0)
+  provider = aws.provisionassessment
+
+  device_name = local.docker_ebs_device_name
+  instance_id = aws_instance.assessorportal[count.index].id
+  volume_id   = aws_ebs_volume.assessorportal_docker[count.index].id
+}

--- a/assessorportal_iam.tf
+++ b/assessorportal_iam.tf
@@ -1,0 +1,42 @@
+# Create the IAM instance profile for the Assessor Portal EC2 instances
+
+# The instance profile to be used
+resource "aws_iam_instance_profile" "assessorportal" {
+  provider = aws.provisionassessment
+
+  name = "assessorportal_instance_profile_${terraform.workspace}"
+  role = aws_iam_role.assessorportal_instance_role.name
+}
+
+# The instance role
+resource "aws_iam_role" "assessorportal_instance_role" {
+  provider = aws.provisionassessment
+
+  name               = "assessorportal_instance_role_${terraform.workspace}"
+  assume_role_policy = data.aws_iam_policy_document.ec2_service_assume_role_doc.json
+}
+
+# Attach the CloudWatch Agent policy to this role as well
+resource "aws_iam_role_policy_attachment" "cloudwatch_agent_policy_attachment_assessorportal" {
+  provider = aws.provisionassessment
+
+  role       = aws_iam_role.assessorportal_instance_role.id
+  policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
+}
+
+# Attach the SSM Agent policy to this role as well
+resource "aws_iam_role_policy_attachment" "ssm_agent_policy_attachment_assessorportal" {
+  provider = aws.provisionassessment
+
+  role       = aws_iam_role.assessorportal_instance_role.id
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+# Attach a policy that allows the Assessor Portal instances to mount and
+# write to the EFS
+resource "aws_iam_role_policy_attachment" "efs_mount_policy_attachment_assessorportal" {
+  provider = aws.provisionassessment
+
+  role       = aws_iam_role.assessorportal_instance_role.id
+  policy_arn = aws_iam_policy.efs_mount_policy.arn
+}

--- a/assessorportal_route53.tf
+++ b/assessorportal_route53.tf
@@ -1,0 +1,11 @@
+# Private DNS A record for Assessor Portal instances
+resource "aws_route53_record" "assessorportal_A" {
+  count    = lookup(var.operations_instance_counts, "assessorportal", 0)
+  provider = aws.provisionassessment
+
+  zone_id = aws_route53_zone.assessment_private.zone_id
+  name    = "assessorportal${count.index}.${aws_route53_zone.assessment_private.name}"
+  type    = "A"
+  ttl     = var.dns_ttl
+  records = [aws_instance.assessorportal[count.index].private_ip]
+}

--- a/assessorportal_sg.tf
+++ b/assessorportal_sg.tf
@@ -1,0 +1,41 @@
+# Security group for the Assessor Portal instances
+resource "aws_security_group" "assessorportal" {
+  provider = aws.provisionassessment
+
+  vpc_id = aws_vpc.assessment.id
+
+  tags = {
+    "Name" = "Assessor Portal"
+  }
+}
+
+# Allow egress to anywhere via HTTP and HTTPS
+#
+# For: Assessment team web access, package downloads and updates
+resource "aws_security_group_rule" "assessorportal_egress_to_anywhere_via_http_and_https" {
+  for_each = toset(["80", "443"])
+  provider = aws.provisionassessment
+
+  security_group_id = aws_security_group.assessorportal.id
+  type              = "egress"
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = each.key
+  to_port           = each.key
+}
+
+# Allow ingress from anywhere via the allowed ports
+resource "aws_security_group_rule" "ingress_from_anywhere_to_assessorportal_via_allowed_ports" {
+  provider = aws.provisionassessment
+  # for_each will only accept a map or a list of strings, so we have
+  # to do a little finagling to get the list of port objects into an
+  # acceptable form.
+  for_each = { for index, d in var.inbound_ports_allowed["assessorportal"] : index => d }
+
+  security_group_id = aws_security_group.assessorportal.id
+  type              = "ingress"
+  protocol          = each.value["protocol"]
+  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = each.value["from_port"]
+  to_port           = each.value["to_port"]
+}

--- a/guacamole_cloud_init.tf
+++ b/guacamole_cloud_init.tf
@@ -84,7 +84,7 @@ data "cloudinit_config" "guacamole_cloud_init_tasks" {
         aws_region                       = var.aws_region
         guac_connection_setup_filename   = "01_setup_guac_connections"
         guac_connection_setup_path       = var.guac_connection_setup_path
-        instance_hostnames               = join(",", concat(aws_route53_record.debiandesktop_A[*].name, aws_route53_record.gophish_A[*].name, aws_route53_record.kali_A[*].name, aws_route53_record.pentestportal_A[*].name, aws_route53_record.teamserver_A[*].name))
+        instance_hostnames               = join(",", concat(aws_route53_record.assessorportal_A[*].name, aws_route53_record.debiandesktop_A[*].name, aws_route53_record.gophish_A[*].name, aws_route53_record.kali_A[*].name, aws_route53_record.pentestportal_A[*].name, aws_route53_record.teamserver_A[*].name))
         ssm_vnc_read_role_arn            = aws_iam_role.vnc_parameterstorereadonly_role.arn
         ssm_key_vnc_password             = var.ssm_key_vnc_password
         ssm_key_vnc_user                 = var.ssm_key_vnc_username

--- a/variables.tf
+++ b/variables.tf
@@ -75,8 +75,8 @@ variable "guac_connection_setup_path" {
 
 variable "inbound_ports_allowed" {
   type        = map(list(object({ protocol = string, from_port = number, to_port = number })))
-  description = "A map specifying the ports allowed inbound (from anywhere) to the various instance types (e.g. {\"kali\": [{\"protocol\": \"tcp\", \"from_port\": 8000, \"to_port\": 8999}]}).  The currently-supported keys are: \"debiandesktop\", \"gophish\", \"kali\", \"nessus\", \"pentestportal\", and \"teamserver\"."
-  default     = { "debiandesktop" : [], "gophish" : [{ "protocol" : "tcp", "from_port" : 25, "to_port" : 25 }, { "protocol" : "tcp", "from_port" : 80, "to_port" : 80 }, { "protocol" : "tcp", "from_port" : 443, "to_port" : 443 }, { "protocol" : "tcp", "from_port" : 587, "to_port" : 587 }], "kali" : [{ "protocol" : "tcp", "from_port" : 8000, "to_port" : 8999 }], "nessus" : [], "pentestportal" : [], "teamserver" : [{ "protocol" : "tcp", "from_port" : 25, "to_port" : 25 }, { "protocol" : "tcp", "from_port" : 53, "to_port" : 53 }, { "protocol" : "tcp", "from_port" : 80, "to_port" : 80 }, { "protocol" : "tcp", "from_port" : 443, "to_port" : 443 }, { "protocol" : "tcp", "from_port" : 587, "to_port" : 587 }, { "protocol" : "udp", "from_port" : 53, "to_port" : 53 }, { "protocol" : "udp", "from_port" : 8080, "to_port" : 8080 }, { "protocol" : "tcp", "from_port" : 8000, "to_port" : 8999 }] }
+  description = "A map specifying the ports allowed inbound (from anywhere) to the various instance types (e.g. {\"kali\": [{\"protocol\": \"tcp\", \"from_port\": 8000, \"to_port\": 8999}]}).  The currently-supported keys are: \"assessorportal\", \"debiandesktop\", \"gophish\", \"kali\", \"nessus\", \"pentestportal\", and \"teamserver\"."
+  default     = { "assessorportal" : [], "debiandesktop" : [], "gophish" : [{ "protocol" : "tcp", "from_port" : 25, "to_port" : 25 }, { "protocol" : "tcp", "from_port" : 80, "to_port" : 80 }, { "protocol" : "tcp", "from_port" : 443, "to_port" : 443 }, { "protocol" : "tcp", "from_port" : 587, "to_port" : 587 }], "kali" : [{ "protocol" : "tcp", "from_port" : 8000, "to_port" : 8999 }], "nessus" : [], "pentestportal" : [], "teamserver" : [{ "protocol" : "tcp", "from_port" : 25, "to_port" : 25 }, { "protocol" : "tcp", "from_port" : 53, "to_port" : 53 }, { "protocol" : "tcp", "from_port" : 80, "to_port" : 80 }, { "protocol" : "tcp", "from_port" : 443, "to_port" : 443 }, { "protocol" : "tcp", "from_port" : 587, "to_port" : 587 }, { "protocol" : "udp", "from_port" : 53, "to_port" : 53 }, { "protocol" : "udp", "from_port" : 8080, "to_port" : 8080 }, { "protocol" : "tcp", "from_port" : 8000, "to_port" : 8999 }] }
 }
 
 variable "nessus_activation_codes" {
@@ -87,7 +87,7 @@ variable "nessus_activation_codes" {
 
 variable "operations_instance_counts" {
   type        = map(number)
-  description = "A map specifying how many instances of each type should be created in the operations subnet (e.g. { \"kali\": 1 }).  The currently-supported instance keys are: [\"debiandesktop\", \"gophish\", \"kali\", \"nessus\", \"pentestportal\", \"teamserver\"]."
+  description = "A map specifying how many instances of each type should be created in the operations subnet (e.g. { \"kali\": 1 }).  The currently-supported instance keys are: [\"assessorportal\", \"debiandesktop\", \"gophish\", \"kali\", \"nessus\", \"pentestportal\", \"teamserver\"]."
   default     = { "kali" : 1 }
 }
 


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds a new operations instance type called `assessorportal` that hosts the Assessor Portal application.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This is the final piece of work required for https://github.com/cisagov/cool-system/issues/202.  It is dependent on https://github.com/cisagov/assessor-portal-packer/pull/1 (which is dependent on https://github.com/cisagov/ansible-role-assessor-portal/pull/3).

Note that Assessor Portal instances include persistent Docker data storage on an EBS volume.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

All of the following items were validated:
- [x] An Assessor Portal instance could be successfully deployed into the COOL
- [x] The Assessor Portal web application could be successfully started and accessed locally from a browser on the Assessor Portal instance
- [x] Multiple Assessor Portal instances could be successfully deployed in the same COOL assessment environment
- [x] An operator on one Assessor Portal instance could NOT access a running Assessor Portal web application on a different Assessor Portal instance
- [x] The Assessor Portal web application (once started) could NOT be accessed from any other instances in the COOL assessment environment
- [x] The Assessor Portal web application (once started) could NOT be accessed externally via the Internet

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
