### PR TITLE
Make Terraformer instances mount the EFS share

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,14 +79,14 @@ the COOL environment.
 
 | Name | Version |
 |------|---------|
-| aws | ~> 3.38 |
-| aws.dns\_sharedservices | ~> 3.38 |
-| aws.organizationsreadonly | ~> 3.38 |
-| aws.provisionassessment | ~> 3.38 |
-| aws.provisionparameterstorereadrole | ~> 3.38 |
-| aws.provisionsharedservices | ~> 3.38 |
-| cloudinit | ~> 2.0 |
-| null | ~> 3.0 |
+| aws | 3.59.0 |
+| aws.dns\_sharedservices | 3.59.0 |
+| aws.organizationsreadonly | 3.59.0 |
+| aws.provisionassessment | 3.59.0 |
+| aws.provisionparameterstorereadrole | 3.59.0 |
+| aws.provisionsharedservices | 3.59.0 |
+| cloudinit | 2.2.0 |
+| null | 3.1.0 |
 | terraform | n/a |
 
 ## Modules ##
@@ -166,6 +166,7 @@ the COOL environment.
 | [aws_iam_role_policy_attachment.efs_mount_policy_attachment_kali](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.efs_mount_policy_attachment_pentestportal](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.efs_mount_policy_attachment_teamserver](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.efs_mount_policy_attachment_terraformer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.nessus_parameterstorereadonly_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.provisionassessment_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.read_only_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
@@ -200,11 +201,13 @@ the COOL environment.
 | [aws_network_acl_rule.operations_ingress_from_anywhere_via_ports_1024_thru_3388](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
 | [aws_network_acl_rule.operations_ingress_from_anywhere_via_ports_3390_thru_5900](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
 | [aws_network_acl_rule.operations_ingress_from_anywhere_via_ports_50051_thru_65535](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
-| [aws_network_acl_rule.operations_ingress_from_anywhere_via_ports_5902_thru_50049](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
+| [aws_network_acl_rule.operations_ingress_from_anywhere_via_ports_5902_thru_5985](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
+| [aws_network_acl_rule.operations_ingress_from_anywhere_via_ports_5987_thru_50049](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
 | [aws_network_acl_rule.operations_ingress_from_private_via_http](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
 | [aws_network_acl_rule.operations_ingress_from_private_via_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
 | [aws_network_acl_rule.operations_ingress_from_private_via_ssh](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
 | [aws_network_acl_rule.operations_ingress_from_private_via_vnc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
+| [aws_network_acl_rule.operations_ingress_from_private_via_winrm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
 | [aws_network_acl_rule.private_egress_to_anywhere_via_http](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
 | [aws_network_acl_rule.private_egress_to_anywhere_via_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
 | [aws_network_acl_rule.private_egress_to_anywhere_via_ssh](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
@@ -213,10 +216,13 @@ the COOL environment.
 | [aws_network_acl_rule.private_egress_to_operations_via_ephemeral_ports](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
 | [aws_network_acl_rule.private_egress_to_operations_via_ssh](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
 | [aws_network_acl_rule.private_egress_to_operations_via_vnc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
-| [aws_network_acl_rule.private_ingress_from_anywhere_via_ephemeral_ports_1](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
-| [aws_network_acl_rule.private_ingress_from_anywhere_via_ephemeral_ports_2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
-| [aws_network_acl_rule.private_ingress_from_cool_vpn_via_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
-| [aws_network_acl_rule.private_ingress_from_operations_via_ephemeral_ports](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
+| [aws_network_acl_rule.private_egress_to_operations_via_winrm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
+| [aws_network_acl_rule.private_ingress_from_anywhere_else_efs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
+| [aws_network_acl_rule.private_ingress_from_anywhere_else_services](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
+| [aws_network_acl_rule.private_ingress_from_anywhere_via_ephemeral_ports](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
+| [aws_network_acl_rule.private_ingress_from_cool_vpn_services](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
+| [aws_network_acl_rule.private_ingress_from_operations_efs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
+| [aws_network_acl_rule.private_ingress_from_operations_mattermost_web](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
 | [aws_network_acl_rule.private_ingress_from_operations_via_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
 | [aws_network_acl_rule.private_ingress_to_tg_attachment_via_ipa_ports](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
 | [aws_route.cool_operations](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
@@ -319,6 +325,7 @@ the COOL environment.
 | [aws_security_group_rule.terraformer_egress_anywhere_via_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.terraformer_egress_anywhere_via_ssh](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.terraformer_egress_to_dynamodb_via_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.terraformer_egress_to_operations_via_winrm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.terraformer_egress_to_s3_via_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.terraformer_egress_to_sts_via_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_subnet.operations](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |

--- a/README.md
+++ b/README.md
@@ -79,14 +79,14 @@ the COOL environment.
 
 | Name | Version |
 |------|---------|
-| aws | 3.59.0 |
-| aws.dns\_sharedservices | 3.59.0 |
-| aws.organizationsreadonly | 3.59.0 |
-| aws.provisionassessment | 3.59.0 |
-| aws.provisionparameterstorereadrole | 3.59.0 |
-| aws.provisionsharedservices | 3.59.0 |
-| cloudinit | 2.2.0 |
-| null | 3.1.0 |
+| aws | ~> 3.38 |
+| aws.dns\_sharedservices | ~> 3.38 |
+| aws.organizationsreadonly | ~> 3.38 |
+| aws.provisionassessment | ~> 3.38 |
+| aws.provisionparameterstorereadrole | ~> 3.38 |
+| aws.provisionsharedservices | ~> 3.38 |
+| cloudinit | ~> 2.0 |
+| null | ~> 3.0 |
 | terraform | n/a |
 
 ## Modules ##
@@ -483,7 +483,7 @@ the COOL environment.
 | terraformer\_instances | The Terraformer instances. |
 | terraformer\_security\_group | The security group for the Terraformer instances. |
 | vpc | The VPC for this assessment environment. |
-| vpn_server_cidr_block | The CIDR block for the COOL VPN. |
+| vpn\_server\_cidr\_block | The CIDR block for the COOL VPN. |
 
 ## Notes ##
 

--- a/terraformer_cloud_init.tf
+++ b/terraformer_cloud_init.tf
@@ -10,6 +10,34 @@ data "cloudinit_config" "terraformer_cloud_init_tasks" {
   # filenames will also be used as a filename in the scripts
   # directory.
 
+  # Create an fstab entry for the EFS share
+  part {
+    content = templatefile(
+      "${path.module}/cloud-init/efs-mount.tpl.yml", {
+        # Just mount the EFS mount target in the first private subnet
+        efs_id      = aws_efs_mount_target.target[var.private_subnet_cidr_blocks[0]].file_system_id
+        mount_point = "/share"
+    })
+    content_type = "text/cloud-config"
+    filename     = "efs_mount.yml"
+    merge_type   = "list(append)+dict(recurse_array)+str()"
+  }
+
+  # This shell script loops until the EFS share is mounted.  We do
+  # make the instance depend on the EFS share in the Terraform code,
+  # but it is still possible for an instance to boot up without
+  # mounting the share.  See this issue comment for more details:
+  # https://github.com/cisagov/cool-assessment-terraform/issues/85#issuecomment-754052796
+  part {
+    content = templatefile(
+      "${path.module}/cloud-init/mount-efs-share.tpl.sh", {
+        mount_point = "/share"
+    })
+    content_type = "text/x-shellscript"
+    filename     = "mount-efs-share.sh"
+    merge_type   = "list(append)+dict(recurse_array)+str()"
+  }
+
   # Create a credentials file for the VNC user that can be used to
   # configure the AWS CLI to assume the Terraformer role by default
   # and other roles by selecting the correct profile.  For details,
@@ -51,5 +79,6 @@ data "cloudinit_config" "terraformer_cloud_init_tasks" {
     })
     content_type = "text/x-shellscript"
     filename     = "write-aws-config.sh"
+    merge_type   = "list(append)+dict(recurse_array)+str()"
   }
 }

--- a/terraformer_ec2.tf
+++ b/terraformer_ec2.tf
@@ -60,6 +60,7 @@ resource "aws_instance" "terraformer" {
   user_data_base64 = data.cloudinit_config.terraformer_cloud_init_tasks.rendered
   vpc_security_group_ids = [
     aws_security_group.cloudwatch_and_ssm_agent.id,
+    aws_security_group.efs_client.id,
     aws_security_group.guacamole_accessible.id,
     aws_security_group.terraformer.id,
   ]

--- a/terraformer_iam.tf
+++ b/terraformer_iam.tf
@@ -41,6 +41,15 @@ resource "aws_iam_role_policy_attachment" "ssm_agent_policy_attachment_terraform
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
 }
 
+# Attach a policy that allows the Terraformer instances to mount and
+# write to the EFS
+resource "aws_iam_role_policy_attachment" "efs_mount_policy_attachment_terraformer" {
+  provider = aws.provisionassessment
+
+  role       = aws_iam_role.terraformer_instance_role.id
+  policy_arn = aws_iam_policy.efs_mount_policy.arn
+}
+
 ################################
 # Define the role policies below
 ################################


### PR DESCRIPTION
## 🗣 Description ##

This pull request makes the necessary changes to make Terraformer instances mount the EFS share.

## 💭 Motivation and context ##

This is something that the assessors have decided they want after all.

## 🧪 Testing ##

I applied these changes to our `env1-staging` COOL environment and verified that they functioned as expected.

## ✅ Checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.
