### PR TITLE
Add Samba instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,6 +491,10 @@ the COOL environment.
 | private\_subnets | The private subnets. |
 | read\_terraform\_state\_module | The IAM policies and role that allow read-only access to the cool-assessment-terraform workspace-specific state in the Terraform state bucket. |
 | remote\_desktop\_url | The URL of the remote desktop gateway (Guacamole) for this assessment. |
+| samba\_client\_security\_group | The security group that should be applied to all instance types that wish to mount the Samba file share being served by the Samba file share server instances. |
+| samba\_instance\_profile | The instance profile for the Samba file share server instances. |
+| samba\_instances | The Samba file share server instances. |
+| samba\_server\_security\_group | The security group for the Samba file share server instances. |
 | scanner\_security\_group | A security group that should be applied to all instance types that perform scanning.  This security group allows egress to anywhere as well as ingress from anywhere via ICMP. |
 | ssm\_session\_role | An IAM role that allows creation of SSM SessionManager sessions to any EC2 instance in this account. |
 | teamserver\_instance\_profile | The instance profile for the Teamserver instances. |

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ the COOL environment.
 | guacamole\_certreadrole | github.com/cisagov/cert-read-role-tf-module | n/a |
 | read\_terraform\_state | github.com/cisagov/terraform-state-read-role-tf-module | n/a |
 | run\_shell\_ssm\_document | gazoakley/session-manager-settings/aws | n/a |
-| vpc\_flow\_logs | trussworks/vpc-flow-logs/aws | >=2.0.0, <2.1.0 |
+| vpc\_flow\_logs | trussworks/vpc-flow-logs/aws | ~>2.0 |
 
 ## Resources ##
 
@@ -125,6 +125,7 @@ the COOL environment.
 | [aws_iam_instance_profile.kali](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
 | [aws_iam_instance_profile.nessus](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
 | [aws_iam_instance_profile.pentestportal](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
+| [aws_iam_instance_profile.samba](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
 | [aws_iam_instance_profile.teamserver](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
 | [aws_iam_instance_profile.terraformer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
 | [aws_iam_policy.efs_mount_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
@@ -141,6 +142,7 @@ the COOL environment.
 | [aws_iam_role.nessus_instance_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.nessus_parameterstorereadonly_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.pentestportal_instance_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role.samba_instance_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.ssmsession_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.teamserver_instance_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.terraformer_instance_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
@@ -158,6 +160,7 @@ the COOL environment.
 | [aws_iam_role_policy_attachment.cloudwatch_agent_policy_attachment_kali](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.cloudwatch_agent_policy_attachment_nessus](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.cloudwatch_agent_policy_attachment_pentestportal](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.cloudwatch_agent_policy_attachment_samba](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.cloudwatch_agent_policy_attachment_teamserver](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.cloudwatch_agent_policy_attachment_terraformer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.efs_mount_policy_attachment_assessorportal](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
@@ -165,6 +168,7 @@ the COOL environment.
 | [aws_iam_role_policy_attachment.efs_mount_policy_attachment_gophish](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.efs_mount_policy_attachment_kali](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.efs_mount_policy_attachment_pentestportal](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.efs_mount_policy_attachment_samba](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.efs_mount_policy_attachment_teamserver](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.efs_mount_policy_attachment_terraformer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.nessus_parameterstorereadonly_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
@@ -177,6 +181,7 @@ the COOL environment.
 | [aws_iam_role_policy_attachment.ssm_agent_policy_attachment_kali](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.ssm_agent_policy_attachment_nessus](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.ssm_agent_policy_attachment_pentestportal](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.ssm_agent_policy_attachment_samba](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.ssm_agent_policy_attachment_teamserver](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.ssm_agent_policy_attachment_terraformer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.ssmsession_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
@@ -189,6 +194,7 @@ the COOL environment.
 | [aws_instance.kali](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
 | [aws_instance.nessus](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
 | [aws_instance.pentestportal](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
+| [aws_instance.samba](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
 | [aws_instance.teamserver](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
 | [aws_instance.terraformer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
 | [aws_internet_gateway.assessment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/internet_gateway) | resource |
@@ -196,13 +202,13 @@ the COOL environment.
 | [aws_network_acl.operations](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl) | resource |
 | [aws_network_acl.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl) | resource |
 | [aws_network_acl_rule.operations_egress_to_anywhere_via_any_port](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
+| [aws_network_acl_rule.operations_ingress_from_anywhere_else_vnc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
+| [aws_network_acl_rule.operations_ingress_from_anywhere_else_winrm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
 | [aws_network_acl_rule.operations_ingress_from_anywhere_via_allowed_ports](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
 | [aws_network_acl_rule.operations_ingress_from_anywhere_via_icmp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
 | [aws_network_acl_rule.operations_ingress_from_anywhere_via_ports_1024_thru_3388](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
-| [aws_network_acl_rule.operations_ingress_from_anywhere_via_ports_3390_thru_5900](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
+| [aws_network_acl_rule.operations_ingress_from_anywhere_via_ports_3390_thru_50049](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
 | [aws_network_acl_rule.operations_ingress_from_anywhere_via_ports_50051_thru_65535](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
-| [aws_network_acl_rule.operations_ingress_from_anywhere_via_ports_5902_thru_5985](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
-| [aws_network_acl_rule.operations_ingress_from_anywhere_via_ports_5987_thru_50049](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
 | [aws_network_acl_rule.operations_ingress_from_private_via_http](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
 | [aws_network_acl_rule.operations_ingress_from_private_via_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
 | [aws_network_acl_rule.operations_ingress_from_private_via_ssh](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
@@ -223,6 +229,7 @@ the COOL environment.
 | [aws_network_acl_rule.private_ingress_from_cool_vpn_services](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
 | [aws_network_acl_rule.private_ingress_from_operations_efs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
 | [aws_network_acl_rule.private_ingress_from_operations_mattermost_web](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
+| [aws_network_acl_rule.private_ingress_from_operations_smb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
 | [aws_network_acl_rule.private_ingress_from_operations_via_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
 | [aws_network_acl_rule.private_ingress_to_tg_attachment_via_ipa_ports](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
 | [aws_route.cool_operations](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
@@ -237,6 +244,7 @@ the COOL environment.
 | [aws_route53_record.kali_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.nessus_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.pentestportal_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.samba_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.teamserver_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.terraformer_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_vpc_association_authorization.assessment_private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_vpc_association_authorization) | resource |
@@ -258,6 +266,8 @@ the COOL environment.
 | [aws_security_group.nessus](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.pentestportal](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.scanner](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group.smb_client](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group.smb_server](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.ssm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.sts](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.teamserver](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
@@ -301,6 +311,8 @@ the COOL environment.
 | [aws_security_group_rule.ingress_from_nessus_to_sts_via_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ingress_from_pentestportal_to_cloudwatch_via_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ingress_from_pentestportal_to_ssm_via_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.ingress_from_samba_to_cloudwatch_via_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.ingress_from_samba_to_ssm_via_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ingress_from_teamserver_to_cloudwatch_via_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ingress_from_teamserver_to_gophish_via_smtp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ingress_from_teamserver_to_ssm_via_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
@@ -317,6 +329,8 @@ the COOL environment.
 | [aws_security_group_rule.pentestportal_ingress_from_kali_via_web](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.scanner_egress_to_anywhere_via_any_port](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.scanner_ingress_from_anywhere_via_icmp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.smb_client_egress_to_smb_server](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.smb_server_ingress_from_smb_client](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.teamserver_egress_to_gophish_via_587](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.teamserver_egress_to_s3_via_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.teamserver_egress_to_sts_via_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
@@ -363,6 +377,7 @@ the COOL environment.
 | [aws_ami.guacamole](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_ami.kali](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_ami.nessus](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
+| [aws_ami.samba](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_ami.teamserver](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_ami.terraformer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_caller_identity.assessment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
@@ -390,6 +405,7 @@ the COOL environment.
 | [cloudinit_config.guacamole_cloud_init_tasks](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs/data-sources/config) | data source |
 | [cloudinit_config.kali_cloud_init_tasks](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs/data-sources/config) | data source |
 | [cloudinit_config.nessus_cloud_init_tasks](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs/data-sources/config) | data source |
+| [cloudinit_config.samba_cloud_init_tasks](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs/data-sources/config) | data source |
 | [cloudinit_config.teamserver_cloud_init_tasks](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs/data-sources/config) | data source |
 | [cloudinit_config.terraformer_cloud_init_tasks](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs/data-sources/config) | data source |
 | [terraform_remote_state.dns_certboto](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
@@ -414,9 +430,9 @@ the COOL environment.
 | dns\_ttl | The TTL value to use for Route53 DNS records (e.g. 86400).  A smaller value may be useful when the DNS records are changing often, for example when testing. | `number` | `60` | no |
 | email\_sending\_domain | The domain to send emails from within the assessment environment (e.g. "example.com"). | `string` | `"example.com"` | no |
 | guac\_connection\_setup\_path | The full path to the dbinit directory where initialization files must be stored in order to work properly. (e.g. "/var/guacamole/dbinit") | `string` | `"/var/guacamole/dbinit"` | no |
-| inbound\_ports\_allowed | A map specifying the ports allowed inbound (from anywhere) to the various instance types (e.g. {"kali": [{"protocol": "tcp", "from\_port": 8000, "to\_port": 8999}]}).  The currently-supported keys are: "assessorportal", "debiandesktop", "gophish", "kali", "nessus", "pentestportal", "teamserver", and "terraformer". | `map(list(object({ protocol = string, from_port = number, to_port = number })))` | ```{ "assessorportal": [], "debiandesktop": [], "gophish": [ { "from_port": 25, "protocol": "tcp", "to_port": 25 }, { "from_port": 80, "protocol": "tcp", "to_port": 80 }, { "from_port": 443, "protocol": "tcp", "to_port": 443 }, { "from_port": 587, "protocol": "tcp", "to_port": 587 } ], "kali": [ { "from_port": 8000, "protocol": "tcp", "to_port": 8999 } ], "nessus": [], "pentestportal": [], "teamserver": [ { "from_port": 25, "protocol": "tcp", "to_port": 25 }, { "from_port": 53, "protocol": "tcp", "to_port": 53 }, { "from_port": 80, "protocol": "tcp", "to_port": 80 }, { "from_port": 443, "protocol": "tcp", "to_port": 443 }, { "from_port": 587, "protocol": "tcp", "to_port": 587 }, { "from_port": 53, "protocol": "udp", "to_port": 53 }, { "from_port": 8080, "protocol": "udp", "to_port": 8080 }, { "from_port": 8000, "protocol": "tcp", "to_port": 8999 } ], "terraformer": [] }``` | no |
+| inbound\_ports\_allowed | A map specifying the ports allowed inbound (from anywhere) to the various instance types (e.g. {"kali": [{"protocol": "tcp", "from\_port": 8000, "to\_port": 8999}]}).  The currently-supported keys are: "assessorportal", "debiandesktop", "gophish", "kali", "nessus", "pentestportal", "samba", "teamserver", and "terraformer". | `map(list(object({ protocol = string, from_port = number, to_port = number })))` | ```{ "assessorportal": [], "debiandesktop": [], "gophish": [ { "from_port": 25, "protocol": "tcp", "to_port": 25 }, { "from_port": 80, "protocol": "tcp", "to_port": 80 }, { "from_port": 443, "protocol": "tcp", "to_port": 443 }, { "from_port": 587, "protocol": "tcp", "to_port": 587 } ], "kali": [ { "from_port": 8000, "protocol": "tcp", "to_port": 8999 } ], "nessus": [], "pentestportal": [], "samba": [], "teamserver": [ { "from_port": 25, "protocol": "tcp", "to_port": 25 }, { "from_port": 53, "protocol": "tcp", "to_port": 53 }, { "from_port": 80, "protocol": "tcp", "to_port": 80 }, { "from_port": 443, "protocol": "tcp", "to_port": 443 }, { "from_port": 587, "protocol": "tcp", "to_port": 587 }, { "from_port": 53, "protocol": "udp", "to_port": 53 }, { "from_port": 8080, "protocol": "udp", "to_port": 8080 }, { "from_port": 8000, "protocol": "tcp", "to_port": 8999 } ], "terraformer": [] }``` | no |
 | nessus\_activation\_codes | The list of Nessus activation codes (e.g. ["AAAA-BBBB-CCCC-DDDD"]). The number of codes in this list should match the number of Nessus instances defined in operations\_instance\_counts. | `list(string)` | `[]` | no |
-| operations\_instance\_counts | A map specifying how many instances of each type should be created in the operations subnet (e.g. { "kali": 1 }).  The currently-supported instance keys are: ["assessorportal", "debiandesktop", "gophish", "kali", "nessus", "pentestportal", "teamserver", "terraformer"]. | `map(number)` | ```{ "kali": 1 }``` | no |
+| operations\_instance\_counts | A map specifying how many instances of each type should be created in the operations subnet (e.g. { "kali": 1 }).  The currently-supported instance keys are: ["assessorportal", "debiandesktop", "gophish", "kali", "nessus", "pentestportal", "samba", "teamserver", "terraformer"]. | `map(number)` | ```{ "kali": 1 }``` | no |
 | operations\_subnet\_cidr\_block | The operations subnet CIDR block for this assessment (e.g. "10.10.0.0/24"). | `string` | n/a | yes |
 | private\_domain | The local domain to use for this assessment (e.g. "env0"). If not provided, `local.private_domain` will be set to the base of the assessment account name.  For example, if the account name is "env0 (Staging)", `local.private_domain` will default to "env0".  Note that `local.private_domain` should be used in place of `var.private_domain` throughout this project. | `string` | `""` | no |
 | private\_subnet\_cidr\_blocks | The list of private subnet CIDR blocks for this assessment (e.g. ["10.10.1.0/24", "10.10.2.0/24"]). | `list(string)` | n/a | yes |

--- a/assessorportal_ec2.tf
+++ b/assessorportal_ec2.tf
@@ -33,7 +33,6 @@ resource "aws_instance" "assessorportal" {
 
   ami                         = data.aws_ami.assessorportal.id
   associate_public_ip_address = true
-  availability_zone           = "${var.aws_region}${var.aws_availability_zone}"
   iam_instance_profile        = aws_iam_instance_profile.assessorportal.name
   instance_type               = "t3.medium"
   subnet_id                   = aws_subnet.operations.id

--- a/cloudwatch_endpoint_sg.tf
+++ b/cloudwatch_endpoint_sg.tf
@@ -82,6 +82,18 @@ resource "aws_security_group_rule" "ingress_from_pentestportal_to_cloudwatch_via
   to_port                  = 443
 }
 
+# Allow ingress via HTTPS from the Samba security group
+resource "aws_security_group_rule" "ingress_from_samba_to_cloudwatch_via_https" {
+  provider = aws.provisionassessment
+
+  security_group_id        = aws_security_group.cloudwatch.id
+  type                     = "ingress"
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.smb_server.id
+  from_port                = 443
+  to_port                  = 443
+}
+
 # Allow ingress via HTTPS from the teamserver security group
 resource "aws_security_group_rule" "ingress_from_teamserver_to_cloudwatch_via_https" {
   provider = aws.provisionassessment

--- a/debiandesktop_ec2.tf
+++ b/debiandesktop_ec2.tf
@@ -33,7 +33,6 @@ resource "aws_instance" "debiandesktop" {
 
   ami                         = data.aws_ami.debiandesktop.id
   associate_public_ip_address = true
-  availability_zone           = "${var.aws_region}${var.aws_availability_zone}"
   iam_instance_profile        = aws_iam_instance_profile.debiandesktop.name
   instance_type               = "t3.medium"
   subnet_id                   = aws_subnet.operations.id

--- a/gophish_ec2.tf
+++ b/gophish_ec2.tf
@@ -36,7 +36,6 @@ resource "aws_instance" "gophish" {
 
   ami                         = data.aws_ami.gophish.id
   associate_public_ip_address = true
-  availability_zone           = "${var.aws_region}${var.aws_availability_zone}"
   iam_instance_profile        = aws_iam_instance_profile.gophish.name
   instance_type               = "t3.medium"
   subnet_id                   = aws_subnet.operations.id

--- a/guacamole_ec2.tf
+++ b/guacamole_ec2.tf
@@ -42,7 +42,6 @@ resource "aws_instance" "guacamole" {
   ]
 
   ami                  = data.aws_ami.guacamole.id
-  availability_zone    = "${var.aws_region}${var.aws_availability_zone}"
   iam_instance_profile = aws_iam_instance_profile.guacamole.name
   instance_type        = "t3.medium"
   subnet_id            = aws_subnet.private[var.private_subnet_cidr_blocks[0]].id

--- a/kali_ec2.tf
+++ b/kali_ec2.tf
@@ -33,7 +33,6 @@ resource "aws_instance" "kali" {
 
   ami                         = data.aws_ami.kali.id
   associate_public_ip_address = true
-  availability_zone           = "${var.aws_region}${var.aws_availability_zone}"
   iam_instance_profile        = aws_iam_instance_profile.kali.name
   instance_type               = "t3.xlarge"
   subnet_id                   = aws_subnet.operations.id

--- a/nessus_ec2.tf
+++ b/nessus_ec2.tf
@@ -47,7 +47,6 @@ resource "aws_instance" "nessus" {
 
   ami                         = data.aws_ami.nessus.id
   associate_public_ip_address = true
-  availability_zone           = "${var.aws_region}${var.aws_availability_zone}"
   iam_instance_profile        = aws_iam_instance_profile.nessus.name
   instance_type               = "m5.large"
   subnet_id                   = aws_subnet.operations.id

--- a/operations_acl_rules.tf
+++ b/operations_acl_rules.tf
@@ -157,7 +157,7 @@ resource "aws_network_acl_rule" "operations_ingress_from_anywhere_via_ports_1024
 # For: Assessment team operational use, but we don't want to allow
 # public access to RDP on port 3389 or Cobalt Strike Teamservers on port 50050.
 #
-# We can skip the VNC and WINRM ports as they are blocked by rules above.
+# We can skip the VNC and WinRM ports as they are blocked by rules above.
 resource "aws_network_acl_rule" "operations_ingress_from_anywhere_via_ports_3390_thru_50049" {
   provider = aws.provisionassessment
   for_each = toset(local.tcp_and_udp)

--- a/outputs.tf
+++ b/outputs.tf
@@ -173,6 +173,26 @@ output "remote_desktop_url" {
   description = "The URL of the remote desktop gateway (Guacamole) for this assessment."
 }
 
+output "samba_client_security_group" {
+  value       = aws_security_group.smb_client
+  description = "The security group that should be applied to all instance types that wish to mount the Samba file share being served by the Samba file share server instances."
+}
+
+output "samba_instance_profile" {
+  value       = aws_iam_instance_profile.samba
+  description = "The instance profile for the Samba file share server instances."
+}
+
+output "samba_instances" {
+  value       = aws_instance.samba
+  description = "The Samba file share server instances."
+}
+
+output "samba_server_security_group" {
+  value       = aws_security_group.smb_server
+  description = "The security group for the Samba file share server instances."
+}
+
 output "scanner_security_group" {
   value       = aws_security_group.scanner
   description = "A security group that should be applied to all instance types that perform scanning.  This security group allows egress to anywhere as well as ingress from anywhere via ICMP."

--- a/pentestportal_ec2.tf
+++ b/pentestportal_ec2.tf
@@ -33,7 +33,6 @@ resource "aws_instance" "pentestportal" {
 
   ami                         = data.aws_ami.docker.id
   associate_public_ip_address = true
-  availability_zone           = "${var.aws_region}${var.aws_availability_zone}"
   iam_instance_profile        = aws_iam_instance_profile.pentestportal.name
   instance_type               = "t3.small"
   subnet_id                   = aws_subnet.operations.id

--- a/samba_cloud_init.tf
+++ b/samba_cloud_init.tf
@@ -1,0 +1,39 @@
+# cloud-init commands for configuring SMB server instances
+
+data "cloudinit_config" "samba_cloud_init_tasks" {
+  gzip          = true
+  base64_encode = true
+
+  # Note: The filename parameters in each part below are only used to
+  # name the mime-parts of the user-data.  They do not affect the
+  # final name for the templates. For any x-shellscript parts, the
+  # filenames will also be used as a filename in the scripts
+  # directory.
+
+  # Create an fstab entry for the EFS share
+  part {
+    content = templatefile(
+      "${path.module}/cloud-init/efs-mount.tpl.yml", {
+        # Just mount the EFS mount target in the first private subnet
+        efs_id      = aws_efs_mount_target.target[var.private_subnet_cidr_blocks[0]].file_system_id
+        mount_point = "/share"
+    })
+    content_type = "text/cloud-config"
+    filename     = "efs_mount.yml"
+    merge_type   = "list(append)+dict(recurse_array)+str()"
+  }
+
+  # This shell script loops until the EFS share is mounted.  We do
+  # make the instance depend on the EFS share in the Terraform code,
+  # but it is still possible for an instance to boot up without
+  # mounting the share.  See this issue comment for more details:
+  # https://github.com/cisagov/cool-assessment-terraform/issues/85#issuecomment-754052796
+  part {
+    content = templatefile(
+      "${path.module}/cloud-init/mount-efs-share.tpl.sh", {
+        mount_point = "/share"
+    })
+    content_type = "text/x-shellscript"
+    filename     = "mount-efs-share.sh"
+  }
+}

--- a/samba_ec2.tf
+++ b/samba_ec2.tf
@@ -34,7 +34,6 @@ resource "aws_instance" "samba" {
   provider = aws.provisionassessment
 
   ami                  = data.aws_ami.samba.id
-  availability_zone    = "${var.aws_region}${var.aws_availability_zone}"
   iam_instance_profile = aws_iam_instance_profile.samba.name
   instance_type        = "t3.small"
   # TODO: For some reason I can't ssh via SSM to the instance unless I

--- a/samba_ec2.tf
+++ b/samba_ec2.tf
@@ -36,7 +36,7 @@ resource "aws_instance" "samba" {
   ami                  = data.aws_ami.samba.id
   availability_zone    = "${var.aws_region}${var.aws_availability_zone}"
   iam_instance_profile = aws_iam_instance_profile.samba.name
-  instance_type        = "t3.large"
+  instance_type        = "t3.small"
   # TODO: For some reason I can't ssh via SSM to the instance unless I
   # put it in the first private subnet.  I believe this has something
   # to do with the NACLs that are in place for that subnet

--- a/samba_ec2.tf
+++ b/samba_ec2.tf
@@ -1,0 +1,75 @@
+# The Samba AMI
+data "aws_ami" "samba" {
+  provider = aws.provisionassessment
+
+  filter {
+    name = "name"
+    values = [
+      "samba-hvm-*-x86_64-ebs"
+    ]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+
+  owners      = [local.images_account_id]
+  most_recent = true
+}
+
+# The Samba EC2 instances
+resource "aws_instance" "samba" {
+  count = lookup(var.operations_instance_counts, "samba", 0)
+  # These instances require the EFS mount target to be present in
+  # order to mount the EFS volume at boot time.
+  depends_on = [
+    aws_efs_mount_target.target,
+  ]
+  provider = aws.provisionassessment
+
+  ami                  = data.aws_ami.samba.id
+  availability_zone    = "${var.aws_region}${var.aws_availability_zone}"
+  iam_instance_profile = aws_iam_instance_profile.samba.name
+  instance_type        = "t3.large"
+  # TODO: For some reason I can't ssh via SSM to the instance unless I
+  # put it in the first private subnet.  I believe this has something
+  # to do with the NACLs that are in place for that subnet
+  # specifically.  I will figure this out later.  I'd definitely
+  # prefer to put this instance in a different subnet than the
+  # Guacamole instance.
+  #
+  # See cisagov/cool-assessment-terraform#135 for more details.
+  subnet_id = aws_subnet.private[var.private_subnet_cidr_blocks[0]].id
+  # AWS Instance Meta-Data Service (IMDS) options
+  metadata_options {
+    # Enable IMDS (this is the default value)
+    http_endpoint = "enabled"
+    # Restrict put responses from IMDS to a single hop (this is the
+    # default value).  This effectively disallows the retrieval of an
+    # IMDSv2 token via this machine from anywhere else.
+    http_put_response_hop_limit = 1
+    # Require IMDS tokens AKA require the use of IMDSv2
+    http_tokens = "required"
+  }
+  user_data_base64 = data.cloudinit_config.samba_cloud_init_tasks.rendered
+  vpc_security_group_ids = [
+    aws_security_group.cloudwatch_and_ssm_agent.id,
+    aws_security_group.efs_client.id,
+    aws_security_group.smb_server.id,
+  ]
+  tags = {
+    Name = format("Samba%d", count.index)
+  }
+  # volume_tags does not yet inherit the default tags from the
+  # provider.  See hashicorp/terraform-provider-aws#19188 for more
+  # details.
+  volume_tags = merge(data.aws_default_tags.assessment.tags, {
+    Name = format("Samba%d", count.index)
+  })
+}

--- a/samba_iam.tf
+++ b/samba_iam.tf
@@ -1,0 +1,42 @@
+# Create the IAM instance profile for the Samba server EC2 instances
+
+# The instance profile to be used
+resource "aws_iam_instance_profile" "samba" {
+  provider = aws.provisionassessment
+
+  name = "samba_instance_profile_${terraform.workspace}"
+  role = aws_iam_role.samba_instance_role.name
+}
+
+# The instance role
+resource "aws_iam_role" "samba_instance_role" {
+  provider = aws.provisionassessment
+
+  name               = "samba_instance_role_${terraform.workspace}"
+  assume_role_policy = data.aws_iam_policy_document.ec2_service_assume_role_doc.json
+}
+
+# Attach the CloudWatch Agent policy to this role as well
+resource "aws_iam_role_policy_attachment" "cloudwatch_agent_policy_attachment_samba" {
+  provider = aws.provisionassessment
+
+  role       = aws_iam_role.samba_instance_role.id
+  policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
+}
+
+# Attach the SSM Agent policy to this role as well
+resource "aws_iam_role_policy_attachment" "ssm_agent_policy_attachment_samba" {
+  provider = aws.provisionassessment
+
+  role       = aws_iam_role.samba_instance_role.id
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+# Attach a policy that allows the Samba instances to mount and write
+# to the EFS
+resource "aws_iam_role_policy_attachment" "efs_mount_policy_attachment_samba" {
+  provider = aws.provisionassessment
+
+  role       = aws_iam_role.samba_instance_role.id
+  policy_arn = aws_iam_policy.efs_mount_policy.arn
+}

--- a/samba_route53.tf
+++ b/samba_route53.tf
@@ -1,0 +1,11 @@
+# Private DNS A record for Samba server instances
+resource "aws_route53_record" "samba_A" {
+  count    = lookup(var.operations_instance_counts, "samba", 0)
+  provider = aws.provisionassessment
+
+  zone_id = aws_route53_zone.assessment_private.zone_id
+  name    = "samba${count.index}.${aws_route53_zone.assessment_private.name}"
+  type    = "A"
+  ttl     = var.dns_ttl
+  records = [aws_instance.samba[count.index].private_ip]
+}

--- a/smb_client_sg.tf
+++ b/smb_client_sg.tf
@@ -1,0 +1,22 @@
+# Security group for Samba file share clients
+resource "aws_security_group" "smb_client" {
+  provider = aws.provisionassessment
+
+  vpc_id = aws_vpc.assessment.id
+
+  tags = {
+    Name = "SMB client"
+  }
+}
+
+# Allow egress to SMB server instances via port 445 (SMB)
+resource "aws_security_group_rule" "smb_client_egress_to_smb_server" {
+  provider = aws.provisionassessment
+
+  security_group_id        = aws_security_group.smb_client.id
+  type                     = "egress"
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.smb_server.id
+  from_port                = 445
+  to_port                  = 445
+}

--- a/smb_server_sg.tf
+++ b/smb_server_sg.tf
@@ -1,0 +1,22 @@
+# Security group for Samba file share servers
+resource "aws_security_group" "smb_server" {
+  provider = aws.provisionassessment
+
+  vpc_id = aws_vpc.assessment.id
+
+  tags = {
+    Name = "SMB server"
+  }
+}
+
+# Allow ingress from SMB client instances via port 445 (SMB)
+resource "aws_security_group_rule" "smb_server_ingress_from_smb_client" {
+  provider = aws.provisionassessment
+
+  security_group_id        = aws_security_group.smb_server.id
+  type                     = "ingress"
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.smb_client.id
+  from_port                = 445
+  to_port                  = 445
+}

--- a/ssm_endpoint_sg.tf
+++ b/ssm_endpoint_sg.tf
@@ -82,6 +82,18 @@ resource "aws_security_group_rule" "ingress_from_pentestportal_to_ssm_via_https"
   to_port                  = 443
 }
 
+# Allow ingress via HTTPS from the Samba security group
+resource "aws_security_group_rule" "ingress_from_samba_to_ssm_via_https" {
+  provider = aws.provisionassessment
+
+  security_group_id        = aws_security_group.ssm.id
+  type                     = "ingress"
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.smb_server.id
+  from_port                = 443
+  to_port                  = 443
+}
+
 # Allow ingress via HTTPS from the teamserver security group
 resource "aws_security_group_rule" "ingress_from_teamserver_to_ssm_via_https" {
   provider = aws.provisionassessment

--- a/teamserver_ec2.tf
+++ b/teamserver_ec2.tf
@@ -46,7 +46,6 @@ resource "aws_instance" "teamserver" {
 
   ami                         = data.aws_ami.teamserver.id
   associate_public_ip_address = true
-  availability_zone           = "${var.aws_region}${var.aws_availability_zone}"
   iam_instance_profile        = aws_iam_instance_profile.teamserver.name
   instance_type               = "t3.large"
   subnet_id                   = aws_subnet.operations.id

--- a/terraformer_ec2.tf
+++ b/terraformer_ec2.tf
@@ -29,7 +29,6 @@ resource "aws_instance" "terraformer" {
   provider = aws.provisionassessment
 
   ami                  = data.aws_ami.terraformer.id
-  availability_zone    = "${var.aws_region}${var.aws_availability_zone}"
   iam_instance_profile = aws_iam_instance_profile.terraformer.name
   instance_type        = "t3.medium"
   # TODO: For some reason I can't ssh via SSM to the instance unless I

--- a/variables.tf
+++ b/variables.tf
@@ -81,8 +81,8 @@ variable "guac_connection_setup_path" {
 
 variable "inbound_ports_allowed" {
   type        = map(list(object({ protocol = string, from_port = number, to_port = number })))
-  description = "A map specifying the ports allowed inbound (from anywhere) to the various instance types (e.g. {\"kali\": [{\"protocol\": \"tcp\", \"from_port\": 8000, \"to_port\": 8999}]}).  The currently-supported keys are: \"assessorportal\", \"debiandesktop\", \"gophish\", \"kali\", \"nessus\", \"pentestportal\", \"teamserver\", and \"terraformer\"."
-  default     = { "assessorportal" : [], "debiandesktop" : [], "gophish" : [{ "protocol" : "tcp", "from_port" : 25, "to_port" : 25 }, { "protocol" : "tcp", "from_port" : 80, "to_port" : 80 }, { "protocol" : "tcp", "from_port" : 443, "to_port" : 443 }, { "protocol" : "tcp", "from_port" : 587, "to_port" : 587 }], "kali" : [{ "protocol" : "tcp", "from_port" : 8000, "to_port" : 8999 }], "nessus" : [], "pentestportal" : [], "teamserver" : [{ "protocol" : "tcp", "from_port" : 25, "to_port" : 25 }, { "protocol" : "tcp", "from_port" : 53, "to_port" : 53 }, { "protocol" : "tcp", "from_port" : 80, "to_port" : 80 }, { "protocol" : "tcp", "from_port" : 443, "to_port" : 443 }, { "protocol" : "tcp", "from_port" : 587, "to_port" : 587 }, { "protocol" : "udp", "from_port" : 53, "to_port" : 53 }, { "protocol" : "udp", "from_port" : 8080, "to_port" : 8080 }, { "protocol" : "tcp", "from_port" : 8000, "to_port" : 8999 }], "terraformer" : [] }
+  description = "A map specifying the ports allowed inbound (from anywhere) to the various instance types (e.g. {\"kali\": [{\"protocol\": \"tcp\", \"from_port\": 8000, \"to_port\": 8999}]}).  The currently-supported keys are: \"assessorportal\", \"debiandesktop\", \"gophish\", \"kali\", \"nessus\", \"pentestportal\", \"samba\", \"teamserver\", and \"terraformer\"."
+  default     = { "assessorportal" : [], "debiandesktop" : [], "gophish" : [{ "protocol" : "tcp", "from_port" : 25, "to_port" : 25 }, { "protocol" : "tcp", "from_port" : 80, "to_port" : 80 }, { "protocol" : "tcp", "from_port" : 443, "to_port" : 443 }, { "protocol" : "tcp", "from_port" : 587, "to_port" : 587 }], "kali" : [{ "protocol" : "tcp", "from_port" : 8000, "to_port" : 8999 }], "nessus" : [], "pentestportal" : [], "samba" : [], "teamserver" : [{ "protocol" : "tcp", "from_port" : 25, "to_port" : 25 }, { "protocol" : "tcp", "from_port" : 53, "to_port" : 53 }, { "protocol" : "tcp", "from_port" : 80, "to_port" : 80 }, { "protocol" : "tcp", "from_port" : 443, "to_port" : 443 }, { "protocol" : "tcp", "from_port" : 587, "to_port" : 587 }, { "protocol" : "udp", "from_port" : 53, "to_port" : 53 }, { "protocol" : "udp", "from_port" : 8080, "to_port" : 8080 }, { "protocol" : "tcp", "from_port" : 8000, "to_port" : 8999 }], "terraformer" : [] }
 }
 
 variable "nessus_activation_codes" {
@@ -93,7 +93,7 @@ variable "nessus_activation_codes" {
 
 variable "operations_instance_counts" {
   type        = map(number)
-  description = "A map specifying how many instances of each type should be created in the operations subnet (e.g. { \"kali\": 1 }).  The currently-supported instance keys are: [\"assessorportal\", \"debiandesktop\", \"gophish\", \"kali\", \"nessus\", \"pentestportal\", \"teamserver\", \"terraformer\"]."
+  description = "A map specifying how many instances of each type should be created in the operations subnet (e.g. { \"kali\": 1 }).  The currently-supported instance keys are: [\"assessorportal\", \"debiandesktop\", \"gophish\", \"kali\", \"nessus\", \"pentestportal\", \"samba\", \"teamserver\", \"terraformer\"]."
   default     = { "kali" : 1 }
 }
 


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds Samba instances.  These instances re-share the EFS file share via SMB so that they can be mounted by Windows instances.

## 💭 Motivation and context ##

Windows instances cannot mount the EFS share, and AWS FSx requires Active Directory, so this is the best solution for us.

## 🧪 Testing ##

I have tested these changed in env1 of our COOL staging environment.  I created two instances based on the [cisagov/samba-packer](https://github.com/cisagov/samba-packer) AMI and verified that each was sharing the EFS share via SMB.  I then mounted `Samba1`'s SMB share from `Samba0` using `mount -t cifs -o guest,uid=2048,gid=2048 //samba1/Share /mnt/smb` and verified that everything looked like it should.  I also created a text file in the EFS share and changed its ownership to `smbguest:efs_users` and verified that I could read and write it via the SMB share.

## ✅ Checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.
