### PR TITLE
Disallow Terraformer instances from touching ControlTower's CloudFormation foo

### DIFF
--- a/terraformer_policy.tf
+++ b/terraformer_policy.tf
@@ -97,6 +97,21 @@ data "aws_iam_policy_document" "terraformer_policy_doc" {
       aws_network_acl.operations.arn,
     ]
   }
+
+  # Don't allow Terraformer instances to touch the CloudFormation foo
+  # put in place by ControlTower.  This is not covered by the earlier
+  # statement allowing full access to resources that are not tagged as
+  # belonging to the dev team, since CloudFormation resources do not
+  # accept tags.
+  statement {
+    actions = [
+      "cloudformation:*",
+    ]
+    effect = "Deny"
+    resources = [
+      "arn:aws:cloudformation:*:${local.assessment_account_id}:stack/StackSet-AWSControlTower*/*",
+    ]
+  }
 }
 
 resource "aws_iam_policy" "terraformer_policy" {


### PR DESCRIPTION
## 🗣 Description ##

This pull request disallows Terraformer instances from touching the CloudFormation stacks that were created by ControlTower.

## 💭 Motivation and context ##

These resources are not tagged as belonging to the dev team, but they still need to be protected.

## 🧪 Testing ##

I applied these changes to a staging environment in our staging COOL deployment and verified via the AWS CLI that they function as expected.

## ✅ Checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
