### PR TITLE
Make Terraformer access to IAM read-only

### DIFF
--- a/terraformer_policy.tf
+++ b/terraformer_policy.tf
@@ -14,8 +14,8 @@ data "aws_iam_policy_document" "terraformer_policy_doc" {
   # root module, with the exception of IAM.
   #
   # We will attach the arn:aws:iam::aws:policy/ReadOnlyAccess policy
-  # to the same role to which policy document will be attached, which
-  # will give is read-only access to all IAM resources.  We require
+  # to the same role to which the policy document will be attached, which
+  # will give it read-only access to all IAM resources.  We require
   # IAM access to be as read-only as possible in order to stop the
   # Terraformer instance from defeating the Terraformer policy by
   # creating new users, policies, roles, etc.

--- a/terraformer_policy.tf
+++ b/terraformer_policy.tf
@@ -28,6 +28,23 @@ data "aws_iam_policy_document" "terraformer_policy_doc" {
     ]
   }
 
+  # Deny all IAM access unless it is read-only.  This stops the
+  # Terraformer instance from defeating the Terraformer policy by
+  # creating new users, policies, roles, etc.
+  #
+  # I cribbed this list of actions from the AWS built-in policy
+  # arn:aws:iam::aws:policy/IAMReadOnlyAccess.
+  statement {
+    not_actions = [
+      "iam:Get*",
+      "iam:List*",
+    ]
+    effect = "Deny"
+    resources = [
+      "*",
+    ]
+  }
+
   # Allow use of the KMS key used to encrypt COOL AMIs.
   statement {
     actions = [

--- a/terraformer_policy.tf
+++ b/terraformer_policy.tf
@@ -13,11 +13,12 @@ data "aws_iam_policy_document" "terraformer_policy_doc" {
   # _are not_ tagged as being created by the team that deploys this
   # root module, with the exception of IAM.
   #
-  # We will attach the arn:aws:iam::aws:policy/ReadOnlyAccess policy,
-  # which will cover the IAM case.  We require IAM access to be
-  # read-only (as far as is possible) in order to stop the Terraformer
-  # instance from defeating the Terraformer policy by creating new
-  # users, policies, roles, etc.
+  # We will attach the arn:aws:iam::aws:policy/ReadOnlyAccess policy
+  # to the same role to which policy document will be attached, which
+  # will give is read-only access to all IAM resources.  We require
+  # IAM access to be as read-only as possible in order to stop the
+  # Terraformer instance from defeating the Terraformer policy by
+  # creating new users, policies, roles, etc.
   statement {
     condition {
       test = "StringNotEquals"
@@ -36,7 +37,8 @@ data "aws_iam_policy_document" "terraformer_policy_doc" {
 
   # Add an IAM permission to allow the use of our instance roles when
   # spinning up instances, with the exception of our guacamole, samba,
-  # and terraformer instance roles.
+  # and terraformer instance roles.  This is one non-read-only IAM
+  # permission that _is_ necessary.
   statement {
     actions = [
       "iam:PassRole",


### PR DESCRIPTION
## 🗣 Description ##

This pull requests adds a statement to the Terraformer policy document that makes its IAM access read-only.

## 💭 Motivation and context ##

This stops the Terraformer instance from defeating the Terraformer policy by creating new users, policies, roles, etc.  I'm looking at you, @epicfaace!  :smiley:

## 🧪 Testing ##

I successfully applied these changes to env1 in our staging COOL environment.

## ✅ Checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
