### PR TITLE
Add rules to allow anything in the Operations subnet to use the VPC endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,9 @@ the COOL environment.
 | [aws_security_group_rule.ingress_from_nessus_to_cloudwatch_via_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ingress_from_nessus_to_ssm_via_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ingress_from_nessus_to_sts_via_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.ingress_from_operations_subnet_to_cloudwatch_via_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.ingress_from_operations_subnet_to_ssm_via_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.ingress_from_operations_subnet_to_sts_via_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ingress_from_pentestportal_to_cloudwatch_via_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ingress_from_pentestportal_to_ssm_via_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ingress_from_samba_to_cloudwatch_via_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |

--- a/cloudwatch_endpoint_sg.tf
+++ b/cloudwatch_endpoint_sg.tf
@@ -117,3 +117,15 @@ resource "aws_security_group_rule" "ingress_from_terraformer_to_cloudwatch_via_h
   from_port                = 443
   to_port                  = 443
 }
+
+# Allow ingress via HTTPS from the operations subnet
+resource "aws_security_group_rule" "ingress_from_operations_subnet_to_cloudwatch_via_https" {
+  provider = aws.provisionassessment
+
+  security_group_id = aws_security_group.cloudwatch.id
+  type              = "ingress"
+  protocol          = "tcp"
+  cidr_blocks       = [var.operations_subnet_cidr_block]
+  from_port         = 443
+  to_port           = 443
+}

--- a/ssm_endpoint_sg.tf
+++ b/ssm_endpoint_sg.tf
@@ -117,3 +117,15 @@ resource "aws_security_group_rule" "ingress_from_terraformer_to_ssm_via_https" {
   from_port                = 443
   to_port                  = 443
 }
+
+# Allow ingress via HTTPS from the operations subnet
+resource "aws_security_group_rule" "ingress_from_operations_subnet_to_ssm_via_https" {
+  provider = aws.provisionassessment
+
+  security_group_id = aws_security_group.ssm.id
+  type              = "ingress"
+  protocol          = "tcp"
+  cidr_blocks       = [var.operations_subnet_cidr_block]
+  from_port         = 443
+  to_port           = 443
+}

--- a/sts_endpoint_sg.tf
+++ b/sts_endpoint_sg.tf
@@ -68,3 +68,15 @@ resource "aws_security_group_rule" "ingress_from_terraformer_to_sts_via_https" {
   from_port                = 443
   to_port                  = 443
 }
+
+# Allow ingress via HTTPS from the operations subnet
+resource "aws_security_group_rule" "ingress_from_operations_subnet_to_sts_via_https" {
+  provider = aws.provisionassessment
+
+  security_group_id = aws_security_group.sts.id
+  type              = "ingress"
+  protocol          = "tcp"
+  cidr_blocks       = [var.operations_subnet_cidr_block]
+  from_port         = 443
+  to_port           = 443
+}


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds rules to allow anything in the Operations subnet to use the VPC endpoints.

## 💭 Motivation and context ##

This is necessary since instances created via Terraformer live in the Operations subnet, but they do not have a security group that I can list in a SG rule.

## 🧪 Testing ##

I have applied these changes in env3 of our staging COOL environment and verified that they function as expected.

## ✅ Checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.
