### PR TITLE
Add TagSession wherever we allow AssumeRole

### DIFF
--- a/guacamole_iam.tf
+++ b/guacamole_iam.tf
@@ -62,7 +62,10 @@ resource "aws_iam_role_policy_attachment" "ssm_agent_policy_attachment_guacamole
 #  - To read the VNC-related data from the SSM Parameter Store
 data "aws_iam_policy_document" "guacamole_assume_delegated_role_policy_doc" {
   statement {
-    actions = ["sts:AssumeRole"]
+    actions = [
+      "sts:AssumeRole",
+      "sts:TagSession",
+    ]
     resources = [
       module.guacamole_certreadrole.role.arn,
       aws_iam_role.vnc_parameterstorereadonly_role.arn

--- a/kali_iam.tf
+++ b/kali_iam.tf
@@ -16,15 +16,6 @@ resource "aws_iam_role" "kali_instance_role" {
   assume_role_policy = data.aws_iam_policy_document.ec2_service_assume_role_doc.json
 }
 
-# TODO: Determine if needed:
-# resource "aws_iam_role_policy" "kali_assume_delegated_role_policy" {
-#   provider = aws.provisionassessment
-#
-#   name   = "assume_delegated_role_policy"
-#   role   = aws_iam_role.kali_instance_role.id
-#   policy = data.aws_iam_policy_document.kali_assume_delegated_role_policy_doc.json
-# }
-
 # Attach the CloudWatch Agent policy to this role as well
 resource "aws_iam_role_policy_attachment" "cloudwatch_agent_policy_attachment_kali" {
   provider = aws.provisionassessment
@@ -49,18 +40,3 @@ resource "aws_iam_role_policy_attachment" "efs_mount_policy_attachment_kali" {
   role       = aws_iam_role.kali_instance_role.id
   policy_arn = aws_iam_policy.efs_mount_policy.arn
 }
-
-################################
-# Define the role policies below
-################################
-
-# TODO: Determine if needed:
-# # Allow the Kali instance to assume the necessary roles:
-# data "aws_iam_policy_document" "kali_assume_delegated_role_policy_doc" {
-#   statement {
-#     actions = ["sts:AssumeRole"]
-#     resources = [
-#     ]
-#     effect = "Allow"
-#   }
-# }

--- a/nessus_assume_role_policy_doc.tf
+++ b/nessus_assume_role_policy_doc.tf
@@ -7,6 +7,7 @@ data "aws_iam_policy_document" "nessus_assume_role_doc" {
   statement {
     actions = [
       "sts:AssumeRole",
+      "sts:TagSession",
     ]
 
     principals {

--- a/nessus_iam.tf
+++ b/nessus_iam.tf
@@ -48,7 +48,10 @@ resource "aws_iam_role_policy_attachment" "ssm_agent_policy_attachment_nessus" {
 # to read the Nessus-related data from the SSM Parameter Store
 data "aws_iam_policy_document" "nessus_assume_delegated_role_policy_doc" {
   statement {
-    actions = ["sts:AssumeRole"]
+    actions = [
+      "sts:AssumeRole",
+      "sts:TagSession",
+    ]
     resources = [
       aws_iam_role.nessus_parameterstorereadonly_role.arn
     ]

--- a/users_account_assume_role_policy.tf
+++ b/users_account_assume_role_policy.tf
@@ -7,6 +7,7 @@ data "aws_iam_policy_document" "users_account_assume_role_doc" {
   statement {
     actions = [
       "sts:AssumeRole",
+      "sts:TagSession",
     ]
 
     principals {

--- a/vnc_assume_role_policy_doc.tf
+++ b/vnc_assume_role_policy_doc.tf
@@ -7,6 +7,7 @@ data "aws_iam_policy_document" "vnc_assume_role_doc" {
   statement {
     actions = [
       "sts:AssumeRole",
+      "sts:TagSession",
     ]
 
     principals {


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds the `sts:TagSession` action to every IAM policy where we already allow `sts:AssumeRole`.  It also removes some old, commented-out code that is not needed.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

If you are allowed to assume a role, you should also be allowed to tag the session.  This change is a result of https://github.com/cisagov/cool-accounts-userservices/pull/15#discussion_r729974117.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

This change was successfully applied in a staging Terraform workspace and no issues were observed.

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
