### PR TITLE
Upgrade volumes to gp3

### DIFF
--- a/assessorportal_ec2.tf
+++ b/assessorportal_ec2.tf
@@ -48,9 +48,8 @@ resource "aws_instance" "assessorportal" {
     http_tokens = "required"
   }
   root_block_device {
-    volume_type           = "gp3"
-    volume_size           = 128
-    delete_on_termination = true
+    volume_type = "gp3"
+    volume_size = 128
   }
   user_data_base64 = data.cloudinit_config.assessorportal_cloud_init_tasks[count.index].rendered
   vpc_security_group_ids = [

--- a/assessorportal_ec2.tf
+++ b/assessorportal_ec2.tf
@@ -48,8 +48,8 @@ resource "aws_instance" "assessorportal" {
     http_tokens = "required"
   }
   root_block_device {
-    volume_type = "gp3"
     volume_size = 128
+    volume_type = "gp3"
   }
   user_data_base64 = data.cloudinit_config.assessorportal_cloud_init_tasks[count.index].rendered
   vpc_security_group_ids = [

--- a/assessorportal_ec2.tf
+++ b/assessorportal_ec2.tf
@@ -48,7 +48,7 @@ resource "aws_instance" "assessorportal" {
     http_tokens = "required"
   }
   root_block_device {
-    volume_type           = "gp2"
+    volume_type           = "gp3"
     volume_size           = 128
     delete_on_termination = true
   }
@@ -82,7 +82,7 @@ resource "aws_ebs_volume" "assessorportal_docker" {
   availability_zone = "${var.aws_region}${var.aws_availability_zone}"
   encrypted         = true
   size              = 16
-  type              = "gp2"
+  type              = "gp3"
 
   tags = {
     Name = format("AssessorPortal%d Docker", count.index)

--- a/debiandesktop_ec2.tf
+++ b/debiandesktop_ec2.tf
@@ -48,7 +48,7 @@ resource "aws_instance" "debiandesktop" {
     http_tokens = "required"
   }
   root_block_device {
-    volume_type           = "gp2"
+    volume_type           = "gp3"
     volume_size           = 128
     delete_on_termination = true
   }

--- a/debiandesktop_ec2.tf
+++ b/debiandesktop_ec2.tf
@@ -48,9 +48,8 @@ resource "aws_instance" "debiandesktop" {
     http_tokens = "required"
   }
   root_block_device {
-    volume_type           = "gp3"
-    volume_size           = 128
-    delete_on_termination = true
+    volume_type = "gp3"
+    volume_size = 128
   }
   # We can use the same cloud-init code as the Kali instances, since
   # all it does is set up /etc/fstab to mount the EFS file share.

--- a/debiandesktop_ec2.tf
+++ b/debiandesktop_ec2.tf
@@ -48,8 +48,8 @@ resource "aws_instance" "debiandesktop" {
     http_tokens = "required"
   }
   root_block_device {
-    volume_type = "gp3"
     volume_size = 128
+    volume_type = "gp3"
   }
   # We can use the same cloud-init code as the Kali instances, since
   # all it does is set up /etc/fstab to mount the EFS file share.

--- a/examples/use-terraformer-instance/teamserver_ec2.tf
+++ b/examples/use-terraformer-instance/teamserver_ec2.tf
@@ -29,8 +29,8 @@ resource "aws_instance" "teamserver" {
   instance_type               = "t3.large"
   subnet_id                   = data.terraform_remote_state.cool_assessment_terraform.outputs.operations_subnet.id
   root_block_device {
-    volume_type = "gp3"
     volume_size = 128
+    volume_type = "gp3"
   }
   # AWS Instance Meta-Data Service (IMDS) options
   metadata_options {

--- a/examples/use-terraformer-instance/teamserver_ec2.tf
+++ b/examples/use-terraformer-instance/teamserver_ec2.tf
@@ -29,9 +29,8 @@ resource "aws_instance" "teamserver" {
   instance_type               = "t3.large"
   subnet_id                   = data.terraform_remote_state.cool_assessment_terraform.outputs.operations_subnet.id
   root_block_device {
-    volume_type           = "gp3"
-    volume_size           = 128
-    delete_on_termination = true
+    volume_type = "gp3"
+    volume_size = 128
   }
   # AWS Instance Meta-Data Service (IMDS) options
   metadata_options {

--- a/examples/use-terraformer-instance/teamserver_ec2.tf
+++ b/examples/use-terraformer-instance/teamserver_ec2.tf
@@ -29,7 +29,7 @@ resource "aws_instance" "teamserver" {
   instance_type               = "t3.large"
   subnet_id                   = data.terraform_remote_state.cool_assessment_terraform.outputs.operations_subnet.id
   root_block_device {
-    volume_type           = "gp2"
+    volume_type           = "gp3"
     volume_size           = 128
     delete_on_termination = true
   }

--- a/gophish_ec2.tf
+++ b/gophish_ec2.tf
@@ -51,9 +51,8 @@ resource "aws_instance" "gophish" {
     http_tokens = "required"
   }
   root_block_device {
-    volume_type           = "gp3"
-    volume_size           = 128
-    delete_on_termination = true
+    volume_type = "gp3"
+    volume_size = 128
   }
   user_data_base64 = data.cloudinit_config.gophish_cloud_init_tasks[count.index].rendered
   vpc_security_group_ids = [

--- a/gophish_ec2.tf
+++ b/gophish_ec2.tf
@@ -51,7 +51,7 @@ resource "aws_instance" "gophish" {
     http_tokens = "required"
   }
   root_block_device {
-    volume_type           = "gp2"
+    volume_type           = "gp3"
     volume_size           = 128
     delete_on_termination = true
   }
@@ -107,7 +107,7 @@ resource "aws_ebs_volume" "gophish_docker" {
   availability_zone = "${var.aws_region}${var.aws_availability_zone}"
   encrypted         = true
   size              = 16
-  type              = "gp2"
+  type              = "gp3"
 
   tags = {
     Name = format("Gophish%d Docker", count.index)

--- a/gophish_ec2.tf
+++ b/gophish_ec2.tf
@@ -51,8 +51,8 @@ resource "aws_instance" "gophish" {
     http_tokens = "required"
   }
   root_block_device {
-    volume_type = "gp3"
     volume_size = 128
+    volume_type = "gp3"
   }
   user_data_base64 = data.cloudinit_config.gophish_cloud_init_tasks[count.index].rendered
   vpc_security_group_ids = [

--- a/guacamole_ec2.tf
+++ b/guacamole_ec2.tf
@@ -57,9 +57,8 @@ resource "aws_instance" "guacamole" {
     http_tokens = "required"
   }
   root_block_device {
-    volume_type           = "gp3"
-    volume_size           = 8
-    delete_on_termination = true
+    volume_type = "gp3"
+    volume_size = 8
   }
   user_data_base64 = data.cloudinit_config.guacamole_cloud_init_tasks.rendered
   vpc_security_group_ids = [

--- a/guacamole_ec2.tf
+++ b/guacamole_ec2.tf
@@ -57,8 +57,8 @@ resource "aws_instance" "guacamole" {
     http_tokens = "required"
   }
   root_block_device {
-    volume_type = "gp3"
     volume_size = 8
+    volume_type = "gp3"
   }
   user_data_base64 = data.cloudinit_config.guacamole_cloud_init_tasks.rendered
   vpc_security_group_ids = [

--- a/guacamole_ec2.tf
+++ b/guacamole_ec2.tf
@@ -57,7 +57,7 @@ resource "aws_instance" "guacamole" {
     http_tokens = "required"
   }
   root_block_device {
-    volume_type           = "gp2"
+    volume_type           = "gp3"
     volume_size           = 8
     delete_on_termination = true
   }

--- a/kali_ec2.tf
+++ b/kali_ec2.tf
@@ -48,8 +48,8 @@ resource "aws_instance" "kali" {
     http_tokens = "required"
   }
   root_block_device {
-    volume_type = "gp3"
     volume_size = 128
+    volume_type = "gp3"
   }
   user_data_base64 = data.cloudinit_config.kali_cloud_init_tasks.rendered
   vpc_security_group_ids = [

--- a/kali_ec2.tf
+++ b/kali_ec2.tf
@@ -48,7 +48,7 @@ resource "aws_instance" "kali" {
     http_tokens = "required"
   }
   root_block_device {
-    volume_type           = "gp2"
+    volume_type           = "gp3"
     volume_size           = 128
     delete_on_termination = true
   }

--- a/kali_ec2.tf
+++ b/kali_ec2.tf
@@ -48,9 +48,8 @@ resource "aws_instance" "kali" {
     http_tokens = "required"
   }
   root_block_device {
-    volume_type           = "gp3"
-    volume_size           = 128
-    delete_on_termination = true
+    volume_type = "gp3"
+    volume_size = 128
   }
   user_data_base64 = data.cloudinit_config.kali_cloud_init_tasks.rendered
   vpc_security_group_ids = [

--- a/nessus_ec2.tf
+++ b/nessus_ec2.tf
@@ -62,9 +62,8 @@ resource "aws_instance" "nessus" {
     http_tokens = "required"
   }
   root_block_device {
-    volume_type           = "gp3"
-    volume_size           = 128
-    delete_on_termination = true
+    volume_type = "gp3"
+    volume_size = 128
   }
   user_data_base64 = data.cloudinit_config.nessus_cloud_init_tasks[count.index].rendered
   vpc_security_group_ids = [

--- a/nessus_ec2.tf
+++ b/nessus_ec2.tf
@@ -62,7 +62,7 @@ resource "aws_instance" "nessus" {
     http_tokens = "required"
   }
   root_block_device {
-    volume_type           = "gp2"
+    volume_type           = "gp3"
     volume_size           = 128
     delete_on_termination = true
   }

--- a/nessus_ec2.tf
+++ b/nessus_ec2.tf
@@ -62,8 +62,8 @@ resource "aws_instance" "nessus" {
     http_tokens = "required"
   }
   root_block_device {
-    volume_type = "gp3"
     volume_size = 128
+    volume_type = "gp3"
   }
   user_data_base64 = data.cloudinit_config.nessus_cloud_init_tasks[count.index].rendered
   vpc_security_group_ids = [

--- a/pentestportal_ec2.tf
+++ b/pentestportal_ec2.tf
@@ -48,8 +48,8 @@ resource "aws_instance" "pentestportal" {
     http_tokens = "required"
   }
   root_block_device {
-    volume_type = "gp3"
     volume_size = 128
+    volume_type = "gp3"
   }
   # We can use the same cloud-init code as the Kali instances, since
   # all it does is set up /etc/fstab to mount the EFS file share.

--- a/pentestportal_ec2.tf
+++ b/pentestportal_ec2.tf
@@ -48,9 +48,8 @@ resource "aws_instance" "pentestportal" {
     http_tokens = "required"
   }
   root_block_device {
-    volume_type           = "gp3"
-    volume_size           = 128
-    delete_on_termination = true
+    volume_type = "gp3"
+    volume_size = 128
   }
   # We can use the same cloud-init code as the Kali instances, since
   # all it does is set up /etc/fstab to mount the EFS file share.

--- a/pentestportal_ec2.tf
+++ b/pentestportal_ec2.tf
@@ -48,7 +48,7 @@ resource "aws_instance" "pentestportal" {
     http_tokens = "required"
   }
   root_block_device {
-    volume_type           = "gp2"
+    volume_type           = "gp3"
     volume_size           = 128
     delete_on_termination = true
   }

--- a/samba_ec2.tf
+++ b/samba_ec2.tf
@@ -56,6 +56,11 @@ resource "aws_instance" "samba" {
     # Require IMDS tokens AKA require the use of IMDSv2
     http_tokens = "required"
   }
+  root_block_device {
+    volume_type           = "gp3"
+    volume_size           = 16
+    delete_on_termination = true
+  }
   user_data_base64 = data.cloudinit_config.samba_cloud_init_tasks.rendered
   vpc_security_group_ids = [
     aws_security_group.cloudwatch_and_ssm_agent.id,

--- a/samba_ec2.tf
+++ b/samba_ec2.tf
@@ -57,8 +57,8 @@ resource "aws_instance" "samba" {
     http_tokens = "required"
   }
   root_block_device {
-    volume_type = "gp3"
     volume_size = 16
+    volume_type = "gp3"
   }
   user_data_base64 = data.cloudinit_config.samba_cloud_init_tasks.rendered
   vpc_security_group_ids = [

--- a/samba_ec2.tf
+++ b/samba_ec2.tf
@@ -57,9 +57,8 @@ resource "aws_instance" "samba" {
     http_tokens = "required"
   }
   root_block_device {
-    volume_type           = "gp3"
-    volume_size           = 16
-    delete_on_termination = true
+    volume_type = "gp3"
+    volume_size = 16
   }
   user_data_base64 = data.cloudinit_config.samba_cloud_init_tasks.rendered
   vpc_security_group_ids = [

--- a/teamserver_ec2.tf
+++ b/teamserver_ec2.tf
@@ -50,7 +50,7 @@ resource "aws_instance" "teamserver" {
   instance_type               = "t3.large"
   subnet_id                   = aws_subnet.operations.id
   root_block_device {
-    volume_type           = "gp2"
+    volume_type           = "gp3"
     volume_size           = 128
     delete_on_termination = true
   }

--- a/teamserver_ec2.tf
+++ b/teamserver_ec2.tf
@@ -50,8 +50,8 @@ resource "aws_instance" "teamserver" {
   instance_type               = "t3.large"
   subnet_id                   = aws_subnet.operations.id
   root_block_device {
-    volume_type = "gp3"
     volume_size = 128
+    volume_type = "gp3"
   }
   # AWS Instance Meta-Data Service (IMDS) options
   metadata_options {

--- a/teamserver_ec2.tf
+++ b/teamserver_ec2.tf
@@ -50,9 +50,8 @@ resource "aws_instance" "teamserver" {
   instance_type               = "t3.large"
   subnet_id                   = aws_subnet.operations.id
   root_block_device {
-    volume_type           = "gp3"
-    volume_size           = 128
-    delete_on_termination = true
+    volume_type = "gp3"
+    volume_size = 128
   }
   # AWS Instance Meta-Data Service (IMDS) options
   metadata_options {

--- a/terraformer_ec2.tf
+++ b/terraformer_ec2.tf
@@ -52,8 +52,8 @@ resource "aws_instance" "terraformer" {
     http_tokens = "required"
   }
   root_block_device {
-    volume_type = "gp3"
     volume_size = 20
+    volume_type = "gp3"
   }
   user_data_base64 = data.cloudinit_config.terraformer_cloud_init_tasks.rendered
   vpc_security_group_ids = [

--- a/terraformer_ec2.tf
+++ b/terraformer_ec2.tf
@@ -52,7 +52,7 @@ resource "aws_instance" "terraformer" {
     http_tokens = "required"
   }
   root_block_device {
-    volume_type           = "gp2"
+    volume_type           = "gp3"
     volume_size           = 20
     delete_on_termination = true
   }

--- a/terraformer_ec2.tf
+++ b/terraformer_ec2.tf
@@ -52,9 +52,8 @@ resource "aws_instance" "terraformer" {
     http_tokens = "required"
   }
   root_block_device {
-    volume_type           = "gp3"
-    volume_size           = 20
-    delete_on_termination = true
+    volume_type = "gp3"
+    volume_size = 20
   }
   user_data_base64 = data.cloudinit_config.terraformer_cloud_init_tasks.rendered
   vpc_security_group_ids = [


### PR DESCRIPTION
## 🗣 Description ##

This pull request:
- Upgrades disk volume types to gp3
- Removes the `delete_on_termination = true` line from `root_block_device` blocks since that is already the default

## 💭 Motivation and context ##

gp3 is 20% cheaper, and the baseline configuration offers better performance than gp2 for volumes smaller than 2TB.  It also allows the volume size and IOPS to be configured separately, whereas the two are intertwined with gp2.

Also note that the volume upgrades are done in place by Terraform, so this change does not result in any instance replacements that must be worked around to avoid disrupting running assessments.

## 🧪 Testing ##

I successfully applied these changes to env1 in our staging COOL environment.

## ✅ Checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
