### PR TITLE
Make the Terraformer instance type larger

### DIFF
--- a/terraformer_ec2.tf
+++ b/terraformer_ec2.tf
@@ -30,7 +30,7 @@ resource "aws_instance" "terraformer" {
 
   ami                  = data.aws_ami.terraformer.id
   iam_instance_profile = aws_iam_instance_profile.terraformer.name
-  instance_type        = "t3.medium"
+  instance_type        = "t3.xlarge"
   # TODO: For some reason I can't ssh via SSM to the instance unless I
   # put it in the first private subnet.  I believe this has something
   # to do with the NACLs that are in place for that subnet


### PR DESCRIPTION
## 🗣 Description ##

This pull request increases the oomph of the Terraformer instance type.

## 💭 Motivation and context ##

The assessors have requested that the Terraformer instance type be made larger, in terms of both RAM and CPU.  The `t3.xlarge` instance type has 4x the RAM and 2x the CPU of the previous `t3.medium` instance type.

## 🧪 Testing ##

All `pre-commit` hooks and GitHub Actions checks pass.

## ✅ Checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
