### PR TITLE
Support multiple email-sending domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,7 +505,7 @@ the COOL environment.
 | debian\_desktop\_security\_group | The security group for the Debian desktop instances. |
 | efs\_client\_security\_group | A security group that should be applied to all instances that will mount the EFS file share. |
 | efs\_mount\_targets | The mount targets for the EFS file share. |
-| email\_sending\_domain\_certreadroles | The IAM roles that allow for reading the certificate for the email-sending domain. |
+| email\_sending\_domain\_certreadroles | The IAM roles that allow for reading the certificate for each email-sending domain. |
 | gophish\_instance\_profiles | The instance profiles for the Gophish instances. |
 | gophish\_instances | The Gophish instances. |
 | gophish\_security\_group | The security group for the Gophish instances. |

--- a/README.md
+++ b/README.md
@@ -466,7 +466,7 @@ the COOL environment.
 | cert\_bucket\_name | The name of the AWS S3 bucket where certificates are stored. | `string` | `"cisa-cool-certificates"` | no |
 | cool\_domain | The domain where the COOL resources reside (e.g. "cool.cyber.dhs.gov"). | `string` | `"cool.cyber.dhs.gov"` | no |
 | dns\_ttl | The TTL value to use for Route53 DNS records (e.g. 86400).  A smaller value may be useful when the DNS records are changing often, for example when testing. | `number` | `60` | no |
-| email\_sending\_domain | The domain to send emails from within the assessment environment (e.g. "example.com"). | `string` | `"example.com"` | no |
+| email\_sending\_domains | The list of domains to send emails from within the assessment environment (e.g. [ "example.com" ]).  Teamserver and Gophish instances will be deployed with each sequential domain in the list, so teamserver0 and gophish0 will get the first domain, teamserver1 and gophish1 will get the second domain, and so on.  If there are more Teamserver or Gophish instances than email-sending domains, the domains in the list will be reused in a wrap-around fashion. For example, if there are three Teamservers and only two email-sending domains, teamserver0 will get the first domain, teamserver1 will get the second domain, and teamserver2 will wrap-around back to using the first domain. | `list(string)` | ```[ "example.com" ]``` | no |
 | guac\_connection\_setup\_path | The full path to the dbinit directory where initialization files must be stored in order to work properly. (e.g. "/var/guacamole/dbinit") | `string` | `"/var/guacamole/dbinit"` | no |
 | inbound\_ports\_allowed | A map specifying the ports allowed inbound (from anywhere) to the various instance types (e.g. {"kali": [{"protocol": "tcp", "from\_port": 443, "to\_port": 443}, {"protocol": "tcp", "from\_port": 9000, "to\_port": 9009}]}).  The currently-supported keys are: "assessorportal", "debiandesktop", "gophish", "kali", "nessus", "pentestportal", "samba", "teamserver", "terraformer", and "windows". | `map(list(object({ protocol = string, from_port = number, to_port = number })))` | ```{ "assessorportal": [], "debiandesktop": [], "gophish": [], "kali": [], "nessus": [], "pentestportal": [], "samba": [], "teamserver": [], "terraformer": [], "windows": [] }``` | no |
 | nessus\_activation\_codes | The list of Nessus activation codes (e.g. ["AAAA-BBBB-CCCC-DDDD"]). The number of codes in this list should match the number of Nessus instances defined in operations\_instance\_counts. | `list(string)` | `[]` | no |
@@ -505,8 +505,8 @@ the COOL environment.
 | debian\_desktop\_security\_group | The security group for the Debian desktop instances. |
 | efs\_client\_security\_group | A security group that should be applied to all instances that will mount the EFS file share. |
 | efs\_mount\_targets | The mount targets for the EFS file share. |
-| email\_sending\_domain\_certreadrole | The IAM role that allows for reading the certificate for the email-sending domain. |
-| gophish\_instance\_profile | The instance profile for the Gophish instances. |
+| email\_sending\_domain\_certreadrole | The IAM roles that allow for reading the certificate for the email-sending domain. |
+| gophish\_instance\_profile | The instance profiles for the Gophish instances. |
 | gophish\_instances | The Gophish instances. |
 | gophish\_security\_group | The security group for the Gophish instances. |
 | guacamole\_accessible\_security\_group | A security group that should be applied to all instances that are to be accessible from Guacamole. |
@@ -534,7 +534,7 @@ the COOL environment.
 | samba\_server\_security\_group | The security group for the Samba file share server instances. |
 | scanner\_security\_group | A security group that should be applied to all instance types that perform scanning.  This security group allows egress to anywhere as well as ingress from anywhere via ICMP. |
 | ssm\_session\_role | An IAM role that allows creation of SSM SessionManager sessions to any EC2 instance in this account. |
-| teamserver\_instance\_profile | The instance profile for the Teamserver instances. |
+| teamserver\_instance\_profile | The instance profiles for the Teamserver instances. |
 | teamserver\_instances | The Teamserver instances. |
 | teamserver\_security\_group | The security group for the Teamserver instances. |
 | terraformer\_instances | The Terraformer instances. |

--- a/README.md
+++ b/README.md
@@ -505,8 +505,8 @@ the COOL environment.
 | debian\_desktop\_security\_group | The security group for the Debian desktop instances. |
 | efs\_client\_security\_group | A security group that should be applied to all instances that will mount the EFS file share. |
 | efs\_mount\_targets | The mount targets for the EFS file share. |
-| email\_sending\_domain\_certreadrole | The IAM roles that allow for reading the certificate for the email-sending domain. |
-| gophish\_instance\_profile | The instance profiles for the Gophish instances. |
+| email\_sending\_domain\_certreadroles | The IAM roles that allow for reading the certificate for the email-sending domain. |
+| gophish\_instance\_profiles | The instance profiles for the Gophish instances. |
 | gophish\_instances | The Gophish instances. |
 | gophish\_security\_group | The security group for the Gophish instances. |
 | guacamole\_accessible\_security\_group | A security group that should be applied to all instances that are to be accessible from Guacamole. |
@@ -534,7 +534,7 @@ the COOL environment.
 | samba\_server\_security\_group | The security group for the Samba file share server instances. |
 | scanner\_security\_group | A security group that should be applied to all instance types that perform scanning.  This security group allows egress to anywhere as well as ingress from anywhere via ICMP. |
 | ssm\_session\_role | An IAM role that allows creation of SSM SessionManager sessions to any EC2 instance in this account. |
-| teamserver\_instance\_profile | The instance profiles for the Teamserver instances. |
+| teamserver\_instance\_profiles | The instance profiles for the Teamserver instances. |
 | teamserver\_instances | The Teamserver instances. |
 | teamserver\_security\_group | The security group for the Teamserver instances. |
 | terraformer\_instances | The Terraformer instances. |

--- a/email_sending_domain_certreadrole.tf
+++ b/email_sending_domain_certreadrole.tf
@@ -12,5 +12,5 @@ module "email_sending_domain_certreadrole" {
   cert_bucket_name = var.cert_bucket_name
   # Certbot stores wildcard certs in a directory with the name of the
   # domain, instead of pre-pending an asterisk.
-  hostname = each.key
+  hostname = each.value
 }

--- a/email_sending_domain_certreadrole.tf
+++ b/email_sending_domain_certreadrole.tf
@@ -1,5 +1,7 @@
 # Create a role that allows an instance to read its certs from S3.
 module "email_sending_domain_certreadrole" {
+  for_each = toset(var.email_sending_domains)
+
   source = "github.com/cisagov/cert-read-role-tf-module"
 
   providers = {
@@ -10,5 +12,5 @@ module "email_sending_domain_certreadrole" {
   cert_bucket_name = var.cert_bucket_name
   # Certbot stores wildcard certs in a directory with the name of the
   # domain, instead of pre-pending an asterisk.
-  hostname = var.email_sending_domain
+  hostname = each.key
 }

--- a/email_sending_domain_certreadrole.tf
+++ b/email_sending_domain_certreadrole.tf
@@ -1,4 +1,5 @@
-# Create a role that allows an instance to read its certs from S3.
+# Create roles that allow each instance to read its email-sending domain
+# certificate from an S3 bucket.
 module "email_sending_domain_certreadrole" {
   for_each = toset(var.email_sending_domains)
 

--- a/examples/use-terraformer-instance/teamserver_cloud_init.tf
+++ b/examples/use-terraformer-instance/teamserver_cloud_init.tf
@@ -58,7 +58,7 @@ data "cloudinit_config" "teamserver_cloud_init_tasks" {
       "${path.module}/../../cloud-init/install-certificates.py", {
         aws_region          = var.aws_region
         cert_bucket_name    = data.terraform_remote_state.cool_assessment_terraform.outputs.certificate_bucket_name
-        cert_read_role_arn  = data.terraform_remote_state.cool_assessment_terraform.outputs.email_sending_domain_certreadrole[var.email_sending_domain].role.arn
+        cert_read_role_arn  = data.terraform_remote_state.cool_assessment_terraform.outputs.email_sending_domain_certreadroles[var.email_sending_domain].role.arn
         create_dest_dirs    = false
         full_chain_pem_dest = local.full_chain_pem
         priv_key_pem_dest   = local.priv_key_pem

--- a/examples/use-terraformer-instance/teamserver_cloud_init.tf
+++ b/examples/use-terraformer-instance/teamserver_cloud_init.tf
@@ -58,7 +58,7 @@ data "cloudinit_config" "teamserver_cloud_init_tasks" {
       "${path.module}/../../cloud-init/install-certificates.py", {
         aws_region          = var.aws_region
         cert_bucket_name    = data.terraform_remote_state.cool_assessment_terraform.outputs.certificate_bucket_name
-        cert_read_role_arn  = data.terraform_remote_state.cool_assessment_terraform.outputs.email_sending_domain_certreadrole.role.arn
+        cert_read_role_arn  = data.terraform_remote_state.cool_assessment_terraform.outputs.email_sending_domain_certreadrole[var.email_sending_domain].role.arn
         create_dest_dirs    = false
         full_chain_pem_dest = local.full_chain_pem
         priv_key_pem_dest   = local.priv_key_pem

--- a/gophish_ec2.tf
+++ b/gophish_ec2.tf
@@ -36,7 +36,7 @@ resource "aws_instance" "gophish" {
 
   ami                         = data.aws_ami.gophish.id
   associate_public_ip_address = true
-  iam_instance_profile        = aws_iam_instance_profile.gophish.name
+  iam_instance_profile        = aws_iam_instance_profile.gophish[count.index].name
   instance_type               = "t3.medium"
   subnet_id                   = aws_subnet.operations.id
   # AWS Instance Meta-Data Service (IMDS) options

--- a/gophish_iam.tf
+++ b/gophish_iam.tf
@@ -3,50 +3,62 @@
 
 # The instance profile to be used
 resource "aws_iam_instance_profile" "gophish" {
+  count = lookup(var.operations_instance_counts, "gophish", 0)
+
   provider = aws.provisionassessment
 
-  name = "gophish_instance_profile_${terraform.workspace}"
-  role = aws_iam_role.gophish_instance_role.name
+  name = "gophish${count.index}_instance_profile_${terraform.workspace}"
+  role = aws_iam_role.gophish_instance_role[count.index].name
 }
 
 # The instance role
 resource "aws_iam_role" "gophish_instance_role" {
+  count = lookup(var.operations_instance_counts, "gophish", 0)
+
   provider = aws.provisionassessment
 
-  name               = "gophish_instance_role_${terraform.workspace}"
+  name               = "gophish${count.index}_instance_role_${terraform.workspace}"
   assume_role_policy = data.aws_iam_policy_document.ec2_service_assume_role_doc.json
 }
 
 resource "aws_iam_role_policy" "gophish_assume_delegated_role_policy" {
+  count = lookup(var.operations_instance_counts, "gophish", 0)
+
   provider = aws.provisionassessment
 
   name   = "assume_delegated_role_policy"
-  role   = aws_iam_role.gophish_instance_role.id
-  policy = data.aws_iam_policy_document.gophish_assume_delegated_role_policy_doc.json
+  role   = aws_iam_role.gophish_instance_role[count.index].id
+  policy = data.aws_iam_policy_document.gophish_assume_delegated_role_policy_doc[count.index].json
 }
 
 # Attach the CloudWatch Agent policy to this role as well
 resource "aws_iam_role_policy_attachment" "cloudwatch_agent_policy_attachment_gophish" {
+  count = lookup(var.operations_instance_counts, "gophish", 0)
+
   provider = aws.provisionassessment
 
-  role       = aws_iam_role.gophish_instance_role.id
+  role       = aws_iam_role.gophish_instance_role[count.index].id
   policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
 }
 
 # Attach the SSM Agent policy to this role as well
 resource "aws_iam_role_policy_attachment" "ssm_agent_policy_attachment_gophish" {
+  count = lookup(var.operations_instance_counts, "gophish", 0)
+
   provider = aws.provisionassessment
 
-  role       = aws_iam_role.gophish_instance_role.id
+  role       = aws_iam_role.gophish_instance_role[count.index].id
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
 }
 
 # Attach a policy that allows the Gophish instances to mount and
 # write to the EFS
 resource "aws_iam_role_policy_attachment" "efs_mount_policy_attachment_gophish" {
+  count = lookup(var.operations_instance_counts, "gophish", 0)
+
   provider = aws.provisionassessment
 
-  role       = aws_iam_role.gophish_instance_role.id
+  role       = aws_iam_role.gophish_instance_role[count.index].id
   policy_arn = aws_iam_policy.efs_mount_policy.arn
 }
 
@@ -55,8 +67,10 @@ resource "aws_iam_role_policy_attachment" "efs_mount_policy_attachment_gophish" 
 ################################
 
 # Allow the Gophish instance to assume the necessary role to read
-# its email-sending domain certificates from an S3 bucket.
+# its email-sending domain certificate from an S3 bucket.
 data "aws_iam_policy_document" "gophish_assume_delegated_role_policy_doc" {
+  count = lookup(var.operations_instance_counts, "gophish", 0)
+
   statement {
     actions = [
       "sts:AssumeRole",
@@ -64,7 +78,7 @@ data "aws_iam_policy_document" "gophish_assume_delegated_role_policy_doc" {
     ]
     effect = "Allow"
     resources = [
-      module.email_sending_domain_certreadrole.role.arn,
+      module.email_sending_domain_certreadrole[element(var.email_sending_domains, count.index)].role.arn,
     ]
   }
 }

--- a/gophish_iam.tf
+++ b/gophish_iam.tf
@@ -1,7 +1,7 @@
 # Create the IAM instance profile for the Gophish EC2 server
 # instances
 
-# The instance profile to be used
+# The instance profiles to be used
 resource "aws_iam_instance_profile" "gophish" {
   count = lookup(var.operations_instance_counts, "gophish", 0)
 
@@ -11,7 +11,7 @@ resource "aws_iam_instance_profile" "gophish" {
   role = aws_iam_role.gophish_instance_role[count.index].name
 }
 
-# The instance role
+# The instance roles
 resource "aws_iam_role" "gophish_instance_role" {
   count = lookup(var.operations_instance_counts, "gophish", 0)
 
@@ -31,7 +31,7 @@ resource "aws_iam_role_policy" "gophish_assume_delegated_role_policy" {
   policy = data.aws_iam_policy_document.gophish_assume_delegated_role_policy_doc[count.index].json
 }
 
-# Attach the CloudWatch Agent policy to this role as well
+# Attach the CloudWatch Agent policy to these roles as well
 resource "aws_iam_role_policy_attachment" "cloudwatch_agent_policy_attachment_gophish" {
   count = lookup(var.operations_instance_counts, "gophish", 0)
 
@@ -41,7 +41,7 @@ resource "aws_iam_role_policy_attachment" "cloudwatch_agent_policy_attachment_go
   policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
 }
 
-# Attach the SSM Agent policy to this role as well
+# Attach the SSM Agent policy to these roles as well
 resource "aws_iam_role_policy_attachment" "ssm_agent_policy_attachment_gophish" {
   count = lookup(var.operations_instance_counts, "gophish", 0)
 
@@ -66,7 +66,7 @@ resource "aws_iam_role_policy_attachment" "efs_mount_policy_attachment_gophish" 
 # Define the role policies below
 ################################
 
-# Allow the Gophish instance to assume the necessary role to read
+# Allow each Gophish instance to assume the necessary role to read
 # its email-sending domain certificate from an S3 bucket.
 data "aws_iam_policy_document" "gophish_assume_delegated_role_policy_doc" {
   count = lookup(var.operations_instance_counts, "gophish", 0)

--- a/outputs.tf
+++ b/outputs.tf
@@ -58,12 +58,12 @@ output "efs_mount_targets" {
   description = "The mount targets for the EFS file share."
 }
 
-output "email_sending_domain_certreadrole" {
+output "email_sending_domain_certreadroles" {
   value       = module.email_sending_domain_certreadrole
   description = "The IAM roles that allow for reading the certificate for the email-sending domain."
 }
 
-output "gophish_instance_profile" {
+output "gophish_instance_profiles" {
   value       = aws_iam_instance_profile.gophish
   description = "The instance profiles for the Gophish instances."
 }
@@ -203,7 +203,7 @@ output "ssm_session_role" {
   description = "An IAM role that allows creation of SSM SessionManager sessions to any EC2 instance in this account."
 }
 
-output "teamserver_instance_profile" {
+output "teamserver_instance_profiles" {
   value       = aws_iam_instance_profile.teamserver
   description = "The instance profiles for the Teamserver instances."
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -60,12 +60,12 @@ output "efs_mount_targets" {
 
 output "email_sending_domain_certreadrole" {
   value       = module.email_sending_domain_certreadrole
-  description = "The IAM role that allows for reading the certificate for the email-sending domain."
+  description = "The IAM roles that allow for reading the certificate for the email-sending domain."
 }
 
 output "gophish_instance_profile" {
   value       = aws_iam_instance_profile.gophish
-  description = "The instance profile for the Gophish instances."
+  description = "The instance profiles for the Gophish instances."
 }
 
 output "gophish_instances" {
@@ -205,7 +205,7 @@ output "ssm_session_role" {
 
 output "teamserver_instance_profile" {
   value       = aws_iam_instance_profile.teamserver
-  description = "The instance profile for the Teamserver instances."
+  description = "The instance profiles for the Teamserver instances."
 }
 
 output "teamserver_instances" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -60,7 +60,7 @@ output "efs_mount_targets" {
 
 output "email_sending_domain_certreadroles" {
   value       = module.email_sending_domain_certreadrole
-  description = "The IAM roles that allow for reading the certificate for the email-sending domain."
+  description = "The IAM roles that allow for reading the certificate for each email-sending domain."
 }
 
 output "gophish_instance_profiles" {

--- a/teamserver_cloud_init.tf
+++ b/teamserver_cloud_init.tf
@@ -8,6 +8,8 @@ locals {
 }
 
 data "cloudinit_config" "teamserver_cloud_init_tasks" {
+  count = lookup(var.operations_instance_counts, "teamserver", 0)
+
   gzip          = true
   base64_encode = true
 
@@ -56,15 +58,21 @@ data "cloudinit_config" "teamserver_cloud_init_tasks" {
   part {
     content = templatefile(
       "${path.module}/cloud-init/install-certificates.py", {
-        aws_region          = var.aws_region
-        cert_bucket_name    = var.cert_bucket_name
-        cert_read_role_arn  = module.email_sending_domain_certreadrole.role.arn
+        aws_region       = var.aws_region
+        cert_bucket_name = var.cert_bucket_name
+        # We use the element() function below instead of the built-in list
+        # index syntax because we want the "wrap-around" behavior provided
+        # by element().  This means that the number of items in
+        # var.email_sending_domains does not have to exactly match the number
+        # of Teamserver instances.  For details, see:
+        # https://www.terraform.io/docs/language/functions/element.html
+        cert_read_role_arn  = module.email_sending_domain_certreadrole[element(var.email_sending_domains, count.index)].role.arn
         create_dest_dirs    = false
         full_chain_pem_dest = local.full_chain_pem
         priv_key_pem_dest   = local.priv_key_pem
         # Certbot stores wildcard certs in a directory with the name
         # of the domain, instead of pre-pending an asterisk.
-        server_fqdn = var.email_sending_domain
+        server_fqdn = element(var.email_sending_domains, count.index)
     })
     content_type = "text/x-shellscript"
     filename     = "01-install-certificates.py"
@@ -75,7 +83,7 @@ data "cloudinit_config" "teamserver_cloud_init_tasks" {
     content = templatefile(
       "${path.module}/cloud-init/add-https-certificate-block-to-cs-profiles.tpl.sh", {
         c2_profile_location = "/tools/Malleable-C2-Profiles/normal"
-        domain              = var.email_sending_domain
+        domain              = element(var.email_sending_domains, count.index)
         full_chain_pem      = local.full_chain_pem
         priv_key_pem        = local.priv_key_pem
     })

--- a/teamserver_ec2.tf
+++ b/teamserver_ec2.tf
@@ -46,7 +46,7 @@ resource "aws_instance" "teamserver" {
 
   ami                         = data.aws_ami.teamserver.id
   associate_public_ip_address = true
-  iam_instance_profile        = aws_iam_instance_profile.teamserver.name
+  iam_instance_profile        = aws_iam_instance_profile.teamserver[count.index].name
   instance_type               = "t3.large"
   subnet_id                   = aws_subnet.operations.id
   root_block_device {
@@ -64,7 +64,7 @@ resource "aws_instance" "teamserver" {
     # Require IMDS tokens AKA require the use of IMDSv2
     http_tokens = "required"
   }
-  user_data_base64 = data.cloudinit_config.teamserver_cloud_init_tasks.rendered
+  user_data_base64 = data.cloudinit_config.teamserver_cloud_init_tasks[count.index].rendered
   vpc_security_group_ids = [
     aws_security_group.cloudwatch_and_ssm_agent.id,
     aws_security_group.efs_client.id,

--- a/teamserver_iam.tf
+++ b/teamserver_iam.tf
@@ -1,7 +1,7 @@
 # Create the IAM instance profile for the Teamserver EC2 server
 # instance
 
-# The instance profile to be used
+# The instance profiles to be used
 resource "aws_iam_instance_profile" "teamserver" {
   count = lookup(var.operations_instance_counts, "teamserver", 0)
 
@@ -11,7 +11,7 @@ resource "aws_iam_instance_profile" "teamserver" {
   role = aws_iam_role.teamserver_instance_role[count.index].name
 }
 
-# The instance role
+# The instance roles
 resource "aws_iam_role" "teamserver_instance_role" {
   count = lookup(var.operations_instance_counts, "teamserver", 0)
 
@@ -31,7 +31,7 @@ resource "aws_iam_role_policy" "teamserver_assume_delegated_role_policy" {
   policy = data.aws_iam_policy_document.teamserver_assume_delegated_role_policy_doc[count.index].json
 }
 
-# Attach the CloudWatch Agent policy to this role as well
+# Attach the CloudWatch Agent policy to these roles as well
 resource "aws_iam_role_policy_attachment" "cloudwatch_agent_policy_attachment_teamserver" {
   count = lookup(var.operations_instance_counts, "teamserver", 0)
 
@@ -41,7 +41,7 @@ resource "aws_iam_role_policy_attachment" "cloudwatch_agent_policy_attachment_te
   policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
 }
 
-# Attach the SSM Agent policy to this role as well
+# Attach the SSM Agent policy to these roles as well
 resource "aws_iam_role_policy_attachment" "ssm_agent_policy_attachment_teamserver" {
   count = lookup(var.operations_instance_counts, "teamserver", 0)
 
@@ -66,7 +66,7 @@ resource "aws_iam_role_policy_attachment" "efs_mount_policy_attachment_teamserve
 # Define the role policies below
 ################################
 
-# Allow the teamserver instance to assume the necessary role to read
+# Allow each Teamserver instance to assume the necessary role to read
 # its email-sending domain certificate from an S3 bucket.
 data "aws_iam_policy_document" "teamserver_assume_delegated_role_policy_doc" {
   count = lookup(var.operations_instance_counts, "teamserver", 0)

--- a/teamserver_iam.tf
+++ b/teamserver_iam.tf
@@ -3,50 +3,62 @@
 
 # The instance profile to be used
 resource "aws_iam_instance_profile" "teamserver" {
+  count = lookup(var.operations_instance_counts, "teamserver", 0)
+
   provider = aws.provisionassessment
 
-  name = "teamserver_instance_profile_${terraform.workspace}"
-  role = aws_iam_role.teamserver_instance_role.name
+  name = "teamserver${count.index}_instance_profile_${terraform.workspace}"
+  role = aws_iam_role.teamserver_instance_role[count.index].name
 }
 
 # The instance role
 resource "aws_iam_role" "teamserver_instance_role" {
+  count = lookup(var.operations_instance_counts, "teamserver", 0)
+
   provider = aws.provisionassessment
 
-  name               = "teamserver_instance_role_${terraform.workspace}"
+  name               = "teamserver${count.index}_instance_role_${terraform.workspace}"
   assume_role_policy = data.aws_iam_policy_document.ec2_service_assume_role_doc.json
 }
 
 resource "aws_iam_role_policy" "teamserver_assume_delegated_role_policy" {
+  count = lookup(var.operations_instance_counts, "teamserver", 0)
+
   provider = aws.provisionassessment
 
   name   = "assume_delegated_role_policy"
-  role   = aws_iam_role.teamserver_instance_role.id
-  policy = data.aws_iam_policy_document.teamserver_assume_delegated_role_policy_doc.json
+  role   = aws_iam_role.teamserver_instance_role[count.index].id
+  policy = data.aws_iam_policy_document.teamserver_assume_delegated_role_policy_doc[count.index].json
 }
 
 # Attach the CloudWatch Agent policy to this role as well
 resource "aws_iam_role_policy_attachment" "cloudwatch_agent_policy_attachment_teamserver" {
+  count = lookup(var.operations_instance_counts, "teamserver", 0)
+
   provider = aws.provisionassessment
 
-  role       = aws_iam_role.teamserver_instance_role.id
+  role       = aws_iam_role.teamserver_instance_role[count.index].id
   policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
 }
 
 # Attach the SSM Agent policy to this role as well
 resource "aws_iam_role_policy_attachment" "ssm_agent_policy_attachment_teamserver" {
+  count = lookup(var.operations_instance_counts, "teamserver", 0)
+
   provider = aws.provisionassessment
 
-  role       = aws_iam_role.teamserver_instance_role.id
+  role       = aws_iam_role.teamserver_instance_role[count.index].id
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
 }
 
 # Attach a policy that allows the Teamserver instances to mount and write to
 # the EFS
 resource "aws_iam_role_policy_attachment" "efs_mount_policy_attachment_teamserver" {
+  count = lookup(var.operations_instance_counts, "teamserver", 0)
+
   provider = aws.provisionassessment
 
-  role       = aws_iam_role.teamserver_instance_role.id
+  role       = aws_iam_role.teamserver_instance_role[count.index].id
   policy_arn = aws_iam_policy.efs_mount_policy.arn
 }
 
@@ -55,8 +67,10 @@ resource "aws_iam_role_policy_attachment" "efs_mount_policy_attachment_teamserve
 ################################
 
 # Allow the teamserver instance to assume the necessary role to read
-# its email-sending domain certificates from an S3 bucket.
+# its email-sending domain certificate from an S3 bucket.
 data "aws_iam_policy_document" "teamserver_assume_delegated_role_policy_doc" {
+  count = lookup(var.operations_instance_counts, "teamserver", 0)
+
   statement {
     actions = [
       "sts:AssumeRole",
@@ -64,7 +78,7 @@ data "aws_iam_policy_document" "teamserver_assume_delegated_role_policy_doc" {
     ]
     effect = "Allow"
     resources = [
-      module.email_sending_domain_certreadrole.role.arn,
+      module.email_sending_domain_certreadrole[element(var.email_sending_domains, count.index)].role.arn,
     ]
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -67,10 +67,10 @@ variable "dns_ttl" {
   default     = 60
 }
 
-variable "email_sending_domain" {
-  type        = string
-  description = "The domain to send emails from within the assessment environment (e.g. \"example.com\")."
-  default     = "example.com"
+variable "email_sending_domains" {
+  type        = list(string)
+  description = "The list of domains to send emails from within the assessment environment (e.g. [ \"example.com\" ]).  Teamserver and Gophish instances will be deployed with each sequential domain in the list, so teamserver0 and gophish0 will get the first domain, teamserver1 and gophish1 will get the second domain, and so on.  If there are more Teamserver or Gophish instances than email-sending domains, the domains in the list will be reused in a wrap-around fashion. For example, if there are three Teamservers and only two email-sending domains, teamserver0 will get the first domain, teamserver1 will get the second domain, and teamserver2 will wrap-around back to using the first domain."
+  default     = ["example.com"]
 }
 
 variable "guac_connection_setup_path" {


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR enables support for multiple email-sending domains by Gophish and Teamserver instances in an assessment environment.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Assessment teams require the ability to have multiple Teamservers deployed in a single assessment environment, each configured with their own email-sending domain.  This is useful if one domain can no longer be feasibly used (e.g. it gets blocked), then the team can quickly switch over to using a different domain.

Both Teamservers and Gophish instances follow the same logic for utilizing domains:

Instances are deployed with each sequential domain in the provided list of email-sending domains, so `teamserver0` and `gophish0` will get the first domain, `teamserver1` and `gophish1` will get the second domain, and so on.  If there are more Teamserver or Gophish instances than email-sending domains, the domains in the list will be reused in a wrap-around fashion. For example, if there are three Teamservers deployed and only two email-sending domains, `teamserver0` will get the first domain, `teamserver1` will get the second domain, and `teamserver2` will wrap-around back to using the first domain.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

Resolves #127 and resolves cisagov/cool-system-internal#42.

## 🧪 Testing ##

I tested these changes by deploying a varying number of Gophish and Teamserver instances, along with a varying number of email-sending domains, then confirming that the expected domain was applied to each instance.

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
