### PR TITLE
Change ownership of the EFS share mount point

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,7 +484,7 @@ the COOL environment.
 | ssm\_key\_nessus\_admin\_password | The AWS SSM Parameter Store parameter that contains the password of the Nessus admin user (e.g. "/nessus/assessment/admin\_password"). | `string` | `"/nessus/assessment/admin_password"` | no |
 | ssm\_key\_nessus\_admin\_username | The AWS SSM Parameter Store parameter that contains the username of the Nessus admin user (e.g. "/nessus/assessment/admin\_username"). | `string` | `"/nessus/assessment/admin_username"` | no |
 | ssm\_key\_samba\_username | The AWS SSM Parameter Store parameter that contains the username of the Samba user (e.g. "/samba/username"). | `string` | `"/samba/username"` | no |
-| ssm\_key\_vnc\_username | The AWS SSM Parameter Store parameter that contains the username of the VNC user on the TBD instance (e.g. "/vnc/username") | `string` | `"/vnc/username"` | no |
+| ssm\_key\_vnc\_username | The AWS SSM Parameter Store parameter that contains the username of the VNC user (e.g. "/vnc/username"). | `string` | `"/vnc/username"` | no |
 | ssmsession\_role\_description | The description to associate with the IAM role (and policy) that allows creation of SSM SessionManager sessions to any EC2 instance in this account. | `string` | `"Allows creation of SSM SessionManager sessions to any EC2 instance in this account."` | no |
 | ssmsession\_role\_name | The name to assign the IAM role (and policy) that allows creation of SSM SessionManager sessions to any EC2 instance in this account. | `string` | `"StartStopSSMSession"` | no |
 | tags | Tags to apply to all AWS resources created | `map(string)` | `{}` | no |

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ the COOL environment.
 | aws | ~> 3.38 |
 | aws.dns\_sharedservices | ~> 3.38 |
 | aws.organizationsreadonly | ~> 3.38 |
+| aws.parameterstorereadonly | ~> 3.38 |
 | aws.provisionassessment | ~> 3.38 |
 | aws.provisionparameterstorereadrole | ~> 3.38 |
 | aws.provisionsharedservices | ~> 3.38 |
@@ -438,6 +439,8 @@ the COOL environment.
 | [aws_iam_policy_document.terraformer_policy_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.users_account_assume_role_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_organizations_organization.cool](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/organizations_organization) | data source |
+| [aws_ssm_parameter.samba_username](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
+| [aws_ssm_parameter.vnc_username](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 | [cloudinit_config.assessorportal_cloud_init_tasks](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs/data-sources/config) | data source |
 | [cloudinit_config.gophish_cloud_init_tasks](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs/data-sources/config) | data source |
 | [cloudinit_config.guacamole_cloud_init_tasks](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs/data-sources/config) | data source |
@@ -480,6 +483,7 @@ the COOL environment.
 | read\_terraform\_state\_role\_name | The name to assign the IAM role (as well as the corresponding policy) that allows read-only access to the cool-assessment-terraform state in the S3 bucket where Terraform state is stored.  The %s in this name will be replaced by the value of the assessment\_account\_name variable. | `string` | `"ReadCoolAssessmentTerraformTerraformState-%s"` | no |
 | ssm\_key\_nessus\_admin\_password | The AWS SSM Parameter Store parameter that contains the password of the Nessus admin user (e.g. "/nessus/assessment/admin\_password"). | `string` | `"/nessus/assessment/admin_password"` | no |
 | ssm\_key\_nessus\_admin\_username | The AWS SSM Parameter Store parameter that contains the username of the Nessus admin user (e.g. "/nessus/assessment/admin\_username"). | `string` | `"/nessus/assessment/admin_username"` | no |
+| ssm\_key\_samba\_username | The AWS SSM Parameter Store parameter that contains the username of the Samba user (e.g. "/samba/username"). | `string` | `"/samba/username"` | no |
 | ssm\_key\_vnc\_username | The AWS SSM Parameter Store parameter that contains the username of the VNC user on the TBD instance (e.g. "/vnc/username") | `string` | `"/vnc/username"` | no |
 | ssmsession\_role\_description | The description to associate with the IAM role (and policy) that allows creation of SSM SessionManager sessions to any EC2 instance in this account. | `string` | `"Allows creation of SSM SessionManager sessions to any EC2 instance in this account."` | no |
 | ssmsession\_role\_name | The name to assign the IAM role (and policy) that allows creation of SSM SessionManager sessions to any EC2 instance in this account. | `string` | `"StartStopSSMSession"` | no |

--- a/assessorportal_cloud_init.tf
+++ b/assessorportal_cloud_init.tf
@@ -18,7 +18,9 @@ data "cloudinit_config" "assessorportal_cloud_init_tasks" {
       "${path.module}/cloud-init/efs-mount.tpl.yml", {
         # Just mount the EFS mount target in the first private subnet
         efs_id      = aws_efs_mount_target.target[var.private_subnet_cidr_blocks[0]].file_system_id
+        group       = "vnc"
         mount_point = "/share"
+        owner       = "vnc"
     })
     content_type = "text/cloud-config"
     filename     = "efs_mount.yml"

--- a/assessorportal_cloud_init.tf
+++ b/assessorportal_cloud_init.tf
@@ -18,9 +18,9 @@ data "cloudinit_config" "assessorportal_cloud_init_tasks" {
       "${path.module}/cloud-init/efs-mount.tpl.yml", {
         # Just mount the EFS mount target in the first private subnet
         efs_id      = aws_efs_mount_target.target[var.private_subnet_cidr_blocks[0]].file_system_id
-        group       = "vnc"
+        group       = data.aws_ssm_parameter.vnc_username.value
         mount_point = "/share"
-        owner       = "vnc"
+        owner       = data.aws_ssm_parameter.vnc_username.value
     })
     content_type = "text/cloud-config"
     filename     = "efs_mount.yml"

--- a/cloud-init/efs-mount.tpl.yml
+++ b/cloud-init/efs-mount.tpl.yml
@@ -3,6 +3,7 @@
 # Create a mount point for the EFS
 runcmd:
   - [mkdir, -p, "${mount_point}"]
+  - [chown, "${owner}:${group}", "${mount_point}"]
 
 # Add an fstab entry for the EFS mount
 mounts:

--- a/examples/use-terraformer-instance/README.md
+++ b/examples/use-terraformer-instance/README.md
@@ -48,6 +48,8 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | aws\_region | The AWS region where the non-global resources for this assessment are to be provisioned (e.g. "us-east-1"). | `string` | `"us-east-1"` | no |
 | dns\_ttl | The TTL value to use for Route53 DNS records (e.g. 86400).  A smaller value may be useful when the DNS records are changing often, for example when testing. | `number` | `60` | no |
+| efs\_mount\_point\_group | The name of the group that should own the EFS share mount point on the deployed instance. | `string` | `"vnc"` | no |
+| efs\_mount\_point\_owner | The name of the user that should own the EFS share mount point on the deployed instance. | `string` | `"vnc"` | no |
 | email\_sending\_domain | The domain to send emails from within the assessment environment (e.g. "example.com"). | `string` | `"example.com"` | no |
 | tags | Tags to apply to all AWS resources created. | `map(string)` | `{}` | no |
 

--- a/examples/use-terraformer-instance/teamserver_cloud_init.tf
+++ b/examples/use-terraformer-instance/teamserver_cloud_init.tf
@@ -23,9 +23,9 @@ data "cloudinit_config" "teamserver_cloud_init_tasks" {
       "${path.module}/../../cloud-init/efs-mount.tpl.yml", {
         # Just mount the EFS mount target in the first private subnet
         efs_id      = data.terraform_remote_state.cool_assessment_terraform.outputs.efs_mount_targets[data.terraform_remote_state.cool_assessment_terraform.outputs.private_subnet_cidr_blocks[0]].file_system_id
-        group       = "vnc"
+        group       = var.efs_mount_point_group
         mount_point = "/share"
-        owner       = "vnc"
+        owner       = var.efs_mount_point_owner
     })
     content_type = "text/cloud-config"
     filename     = "efs_mount.yml"

--- a/examples/use-terraformer-instance/teamserver_cloud_init.tf
+++ b/examples/use-terraformer-instance/teamserver_cloud_init.tf
@@ -23,7 +23,9 @@ data "cloudinit_config" "teamserver_cloud_init_tasks" {
       "${path.module}/../../cloud-init/efs-mount.tpl.yml", {
         # Just mount the EFS mount target in the first private subnet
         efs_id      = data.terraform_remote_state.cool_assessment_terraform.outputs.efs_mount_targets[data.terraform_remote_state.cool_assessment_terraform.outputs.private_subnet_cidr_blocks[0]].file_system_id
+        group       = "vnc"
         mount_point = "/share"
+        owner       = "vnc"
     })
     content_type = "text/cloud-config"
     filename     = "efs_mount.yml"

--- a/examples/use-terraformer-instance/variables.tf
+++ b/examples/use-terraformer-instance/variables.tf
@@ -16,6 +16,18 @@ variable "dns_ttl" {
   default     = 60
 }
 
+variable "efs_mount_point_group" {
+  type        = string
+  description = "The name of the group that should own the EFS share mount point on the deployed instance."
+  default     = "vnc"
+}
+
+variable "efs_mount_point_owner" {
+  type        = string
+  description = "The name of the user that should own the EFS share mount point on the deployed instance."
+  default     = "vnc"
+}
+
 variable "email_sending_domain" {
   type        = string
   description = "The domain to send emails from within the assessment environment (e.g. \"example.com\")."

--- a/gophish_cloud_init.tf
+++ b/gophish_cloud_init.tf
@@ -24,9 +24,9 @@ data "cloudinit_config" "gophish_cloud_init_tasks" {
       "${path.module}/cloud-init/efs-mount.tpl.yml", {
         # Just mount the EFS mount target in the first private subnet
         efs_id      = aws_efs_mount_target.target[var.private_subnet_cidr_blocks[0]].file_system_id
-        group       = "vnc"
+        group       = data.aws_ssm_parameter.vnc_username.value
         mount_point = "/share"
-        owner       = "vnc"
+        owner       = data.aws_ssm_parameter.vnc_username.value
     })
     content_type = "text/cloud-config"
     filename     = "efs_mount.yml"

--- a/gophish_cloud_init.tf
+++ b/gophish_cloud_init.tf
@@ -24,7 +24,9 @@ data "cloudinit_config" "gophish_cloud_init_tasks" {
       "${path.module}/cloud-init/efs-mount.tpl.yml", {
         # Just mount the EFS mount target in the first private subnet
         efs_id      = aws_efs_mount_target.target[var.private_subnet_cidr_blocks[0]].file_system_id
+        group       = "vnc"
         mount_point = "/share"
+        owner       = "vnc"
     })
     content_type = "text/cloud-config"
     filename     = "efs_mount.yml"

--- a/kali_cloud_init.tf
+++ b/kali_cloud_init.tf
@@ -16,9 +16,9 @@ data "cloudinit_config" "kali_cloud_init_tasks" {
       "${path.module}/cloud-init/efs-mount.tpl.yml", {
         # Just mount the EFS mount target in the first private subnet
         efs_id      = aws_efs_mount_target.target[var.private_subnet_cidr_blocks[0]].file_system_id
-        group       = "vnc"
+        group       = data.aws_ssm_parameter.vnc_username.value
         mount_point = "/share"
-        owner       = "vnc"
+        owner       = data.aws_ssm_parameter.vnc_username.value
     })
     content_type = "text/cloud-config"
     filename     = "efs_mount.yml"

--- a/kali_cloud_init.tf
+++ b/kali_cloud_init.tf
@@ -16,7 +16,9 @@ data "cloudinit_config" "kali_cloud_init_tasks" {
       "${path.module}/cloud-init/efs-mount.tpl.yml", {
         # Just mount the EFS mount target in the first private subnet
         efs_id      = aws_efs_mount_target.target[var.private_subnet_cidr_blocks[0]].file_system_id
+        group       = "vnc"
         mount_point = "/share"
+        owner       = "vnc"
     })
     content_type = "text/cloud-config"
     filename     = "efs_mount.yml"

--- a/locals.tf
+++ b/locals.tf
@@ -31,6 +31,23 @@ data "aws_default_tags" "assessment" {
 }
 
 # ------------------------------------------------------------------------------
+# Retrieve SSM Parameter Store parameters.
+# Note: These values are stored in plaintext in the state, but it should be fine
+# because we are using a remote state that we have configured to be encrypted.
+# ------------------------------------------------------------------------------
+data "aws_ssm_parameter" "samba_username" {
+  provider = aws.parameterstorereadonly
+
+  name = var.ssm_key_samba_username
+}
+
+data "aws_ssm_parameter" "vnc_username" {
+  provider = aws.parameterstorereadonly
+
+  name = var.ssm_key_vnc_username
+}
+
+# ------------------------------------------------------------------------------
 # Evaluate expressions for use throughout this configuration.
 # ------------------------------------------------------------------------------
 locals {

--- a/providers.tf
+++ b/providers.tf
@@ -21,6 +21,19 @@ provider "aws" {
   region = var.aws_region # route53 is global, but still required by Terraform
 }
 
+# The provider used to read parameter data from an SSM Parameter Store
+provider "aws" {
+  alias = "parameterstorereadonly"
+  assume_role {
+    role_arn     = data.terraform_remote_state.images_parameterstore.outputs.parameterstorereadonly_role.arn
+    session_name = local.caller_user_name
+  }
+  default_tags {
+    tags = var.tags
+  }
+  region = var.aws_region
+}
+
 # The provider used to create roles that can read certificates from an S3 bucket
 provider "aws" {
   alias = "provisioncertreadrole"

--- a/samba_cloud_init.tf
+++ b/samba_cloud_init.tf
@@ -16,7 +16,9 @@ data "cloudinit_config" "samba_cloud_init_tasks" {
       "${path.module}/cloud-init/efs-mount.tpl.yml", {
         # Just mount the EFS mount target in the first private subnet
         efs_id      = aws_efs_mount_target.target[var.private_subnet_cidr_blocks[0]].file_system_id
+        group       = "smbguest"
         mount_point = "/share"
+        owner       = "smbguest"
     })
     content_type = "text/cloud-config"
     filename     = "efs_mount.yml"

--- a/samba_cloud_init.tf
+++ b/samba_cloud_init.tf
@@ -16,9 +16,9 @@ data "cloudinit_config" "samba_cloud_init_tasks" {
       "${path.module}/cloud-init/efs-mount.tpl.yml", {
         # Just mount the EFS mount target in the first private subnet
         efs_id      = aws_efs_mount_target.target[var.private_subnet_cidr_blocks[0]].file_system_id
-        group       = "smbguest"
+        group       = data.aws_ssm_parameter.samba_username.value
         mount_point = "/share"
-        owner       = "smbguest"
+        owner       = data.aws_ssm_parameter.samba_username.value
     })
     content_type = "text/cloud-config"
     filename     = "efs_mount.yml"

--- a/teamserver_cloud_init.tf
+++ b/teamserver_cloud_init.tf
@@ -25,9 +25,9 @@ data "cloudinit_config" "teamserver_cloud_init_tasks" {
       "${path.module}/cloud-init/efs-mount.tpl.yml", {
         # Just mount the EFS mount target in the first private subnet
         efs_id      = aws_efs_mount_target.target[var.private_subnet_cidr_blocks[0]].file_system_id
-        group       = "vnc"
+        group       = data.aws_ssm_parameter.vnc_username.value
         mount_point = "/share"
-        owner       = "vnc"
+        owner       = data.aws_ssm_parameter.vnc_username.value
     })
     content_type = "text/cloud-config"
     filename     = "efs_mount.yml"

--- a/teamserver_cloud_init.tf
+++ b/teamserver_cloud_init.tf
@@ -25,7 +25,9 @@ data "cloudinit_config" "teamserver_cloud_init_tasks" {
       "${path.module}/cloud-init/efs-mount.tpl.yml", {
         # Just mount the EFS mount target in the first private subnet
         efs_id      = aws_efs_mount_target.target[var.private_subnet_cidr_blocks[0]].file_system_id
+        group       = "vnc"
         mount_point = "/share"
+        owner       = "vnc"
     })
     content_type = "text/cloud-config"
     filename     = "efs_mount.yml"

--- a/terraformer_cloud_init.tf
+++ b/terraformer_cloud_init.tf
@@ -16,9 +16,9 @@ data "cloudinit_config" "terraformer_cloud_init_tasks" {
       "${path.module}/cloud-init/efs-mount.tpl.yml", {
         # Just mount the EFS mount target in the first private subnet
         efs_id      = aws_efs_mount_target.target[var.private_subnet_cidr_blocks[0]].file_system_id
-        group       = "vnc"
+        group       = data.aws_ssm_parameter.vnc_username.value
         mount_point = "/share"
-        owner       = "vnc"
+        owner       = data.aws_ssm_parameter.vnc_username.value
     })
     content_type = "text/cloud-config"
     filename     = "efs_mount.yml"

--- a/terraformer_cloud_init.tf
+++ b/terraformer_cloud_init.tf
@@ -16,7 +16,9 @@ data "cloudinit_config" "terraformer_cloud_init_tasks" {
       "${path.module}/cloud-init/efs-mount.tpl.yml", {
         # Just mount the EFS mount target in the first private subnet
         efs_id      = aws_efs_mount_target.target[var.private_subnet_cidr_blocks[0]].file_system_id
+        group       = "vnc"
         mount_point = "/share"
+        owner       = "vnc"
     })
     content_type = "text/cloud-config"
     filename     = "efs_mount.yml"

--- a/variables.tf
+++ b/variables.tf
@@ -139,6 +139,12 @@ variable "ssm_key_nessus_admin_username" {
   default     = "/nessus/assessment/admin_username"
 }
 
+variable "ssm_key_samba_username" {
+  type        = string
+  description = "The AWS SSM Parameter Store parameter that contains the username of the Samba user (e.g. \"/samba/username\")."
+  default     = "/samba/username"
+}
+
 variable "ssm_key_vnc_username" {
   type        = string
   description = "The AWS SSM Parameter Store parameter that contains the username of the VNC user on the TBD instance (e.g. \"/vnc/username\")"

--- a/variables.tf
+++ b/variables.tf
@@ -147,7 +147,7 @@ variable "ssm_key_samba_username" {
 
 variable "ssm_key_vnc_username" {
   type        = string
-  description = "The AWS SSM Parameter Store parameter that contains the username of the VNC user on the TBD instance (e.g. \"/vnc/username\")"
+  description = "The AWS SSM Parameter Store parameter that contains the username of the VNC user (e.g. \"/vnc/username\")."
   default     = "/vnc/username"
 }
 


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adjusts the cloud-config logic for setting up the EFS share to `chown` the mount point using the provided owner and group.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Currently the mount point is created as the `root` user. This means you must have `root` privileges to access the share. On Kali machines this is fine because `sudo` permissions are configured, but since Windows instances must go through a Samba instance this creates a problem. Currently a Windows instance cannot write to the EFS share until a sub-directory with the appropriate `uid` (the `vnc` and `smbguest` `uid`) has been created. With this in place the Windows instance will be able to immediately write to the EFS share and other system users will not need to `sudo` to access the share.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
Automated tests pass. I deployed this in my testing environment and confirmed that the share is being `chown`ed correctly and the Windows instance is able to write to the root EFS directory with no additional changes.
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
