### PR TITLE
Update Windows EC2 instance storage-related settings

### DIFF
--- a/ec2launch/windows-setup.tpl.yml
+++ b/ec2launch/windows-setup.tpl.yml
@@ -1,17 +1,27 @@
 ---
 version: 1.0
 tasks:
-  # Expand the OS partition and set up the Samba share
+  # Extend the OS partition and set up the Samba share as a network drive
   - task: executeScript
     inputs:
       - frequency: always
         type: powershell
         runAs: localSystem
         content: |-
+          # The Windows AMIs we currently use have a System Reserve partition
+          # that contains boot information in addition to the primary OS
+          # partition. The automatic AWS partition extension in EC2Launch v2
+          # (what we are using to execute userdata) only works if the primary
+          # OS partition is the first partition (partition 1). Since we cannot
+          # use this functionality we manually extend the OS partition
+          # (partition 2) of the instance to use any free space.
           $DiskPath = (Get-Partition -DiskNumber 0).DiskPath
           if ((Get-Partition -DiskId $DiskPath).Count -gt 2) {
             "select disk 0`nselect partition 2`nextend`n" | diskpart.exe
           }
+
+          # If a Samba server is provided add it as a new network drive using
+          # the provided drive letter.
           $SambaServer = ("${samba_server_input}" -split ",")[0]
           if (
             ($SambaServer -ne "") -and

--- a/ec2launch/windows-setup.tpl.yml
+++ b/ec2launch/windows-setup.tpl.yml
@@ -12,16 +12,16 @@ tasks:
           if ((Get-Partition -DiskId $DiskPath).Count -gt 2) {
             "select disk 0`nselect partition 2`nextend`n" | diskpart.exe
           }
-          $samba_server = ("${samba_server_input}" -split ",")[0]
+          $SambaServer = ("${samba_server_input}" -split ",")[0]
           if (
-            ($samba_server -ne "") -and
+            ($SambaServer -ne "") -and
             (-not
               (Get-PSDrive "${drive_letter}" -ErrorAction "SilentlyContinue")
             )
           )
           {
             New-PSDrive -Name "${drive_letter}" `
-              -Root "\\$samba_server\share" `
+              -Root "\\$SambaServer\share" `
               -PSProvider "FileSystem" `
               -Persist
           }

--- a/ec2launch/windows-setup.tpl.yml
+++ b/ec2launch/windows-setup.tpl.yml
@@ -4,7 +4,7 @@ tasks:
   # Expand the OS partition and set up the Samba share
   - task: executeScript
     inputs:
-      - frequency: once
+      - frequency: always
         type: powershell
         runAs: localSystem
         content: |-

--- a/ec2launch/windows-setup.tpl.yml
+++ b/ec2launch/windows-setup.tpl.yml
@@ -8,7 +8,10 @@ tasks:
         type: powershell
         runAs: localSystem
         content: |-
-          "select disk 0`nselect partition 2`nextend`n" | diskpart.exe
+          $DiskPath = (Get-Partition -DriveLetter C).DiskPath
+          if ((Get-Partition -DiskId $DiskPath).Count -gt 2) {
+            "select disk 0`nselect partition 2`nextend`n" | diskpart.exe
+          }
           $samba_server = ("${samba_server_input}" -split ",")[0]
           if (
             ($samba_server -ne "") -and

--- a/ec2launch/windows-setup.tpl.yml
+++ b/ec2launch/windows-setup.tpl.yml
@@ -1,13 +1,14 @@
 ---
 version: 1.0
 tasks:
-  # Set up the Samba share
+  # Expand the OS partition and set up the Samba share
   - task: executeScript
     inputs:
       - frequency: once
         type: powershell
         runAs: localSystem
         content: |-
+          "select disk 0`nselect partition 2`nextend`n" | diskpart.exe
           $samba_server = ("${samba_server_input}" -split ",")[0]
           if (
             ($samba_server -ne "") -and

--- a/ec2launch/windows-setup.tpl.yml
+++ b/ec2launch/windows-setup.tpl.yml
@@ -8,7 +8,7 @@ tasks:
         type: powershell
         runAs: localSystem
         content: |-
-          $DiskPath = (Get-Partition -DriveLetter C).DiskPath
+          $DiskPath = (Get-Partition -DiskNumber 0).DiskPath
           if ((Get-Partition -DiskId $DiskPath).Count -gt 2) {
             "select disk 0`nselect partition 2`nextend`n" | diskpart.exe
           }

--- a/windows_ec2.tf
+++ b/windows_ec2.tf
@@ -47,7 +47,7 @@ resource "aws_instance" "windows" {
   }
   root_block_device {
     volume_type = "gp3"
-    volume_size = 80
+    volume_size = 200
   }
   user_data = templatefile("${path.module}/ec2launch/windows-setup.tpl.yml", { drive_letter = "N", samba_server_input = join(",", aws_route53_record.samba_A[*].name) })
   vpc_security_group_ids = [


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR does the following:

- Bump the default EBS volume for Windows EC2 instances from `80` to `200`
- Update the Windows EC2 userdata to expand the main OS partition if it detects additional partitions
- Update the userdata script to run `always`
- Update to make sure that the script is using PowerShell style variable names
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The default EBS size is increased because the base OS+installed utilities essentially fills the current allocation of `80`. Increasing to `200` should leave plenty of room for operators to perform work. The changes to userdata are primarily focused on resolving https://github.com/cisagov/cool-system-internal/issues/50, but they will require a new AMI that supports this change.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. Using this in my staging environment and Windows instances load with a 200GB OS partition.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [ ] A supporting Windows AMI must exists in both the Production and Staging environments