### PR TITLE
Use an EFS access point to enforce file permissions on the EFS share

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ the COOL environment.
 | [aws_ec2_transit_gateway_route.assessment_route](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_route) | resource |
 | [aws_ec2_transit_gateway_route_table_association.association](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_route_table_association) | resource |
 | [aws_ec2_transit_gateway_vpc_attachment.assessment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_vpc_attachment) | resource |
+| [aws_efs_access_point.access_point](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_access_point) | resource |
 | [aws_efs_file_system.persistent_storage](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_file_system) | resource |
 | [aws_efs_mount_target.target](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_mount_target) | resource |
 | [aws_eip.gophish](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip) | resource |
@@ -461,6 +462,8 @@ the COOL environment.
 | cert\_bucket\_name | The name of the AWS S3 bucket where certificates are stored. | `string` | `"cisa-cool-certificates"` | no |
 | cool\_domain | The domain where the COOL resources reside (e.g. "cool.cyber.dhs.gov"). | `string` | `"cool.cyber.dhs.gov"` | no |
 | dns\_ttl | The TTL value to use for Route53 DNS records (e.g. 86400).  A smaller value may be useful when the DNS records are changing often, for example when testing. | `number` | `60` | no |
+| efs\_access\_point\_gid | The group ID that should be used for file-system access to the EFS share (e.g. 2048).  Note that this value should match the GID of any group given ownership of the EFS share mount point. | `number` | `2048` | no |
+| efs\_access\_point\_uid | The user ID that should be used for file-system access to the EFS share (e.g. 2048).  Note that this value should match the UID of any user given ownership of the EFS share mount point. | `number` | `2048` | no |
 | efs\_users\_group\_name | The name of the POSIX group that should have ownership of a mounted EFS share (e.g. "efs\_users"). | `string` | `"efs_users"` | no |
 | email\_sending\_domains | The list of domains to send emails from within the assessment environment (e.g. [ "example.com" ]).  Teamserver and Gophish instances will be deployed with each sequential domain in the list, so teamserver0 and gophish0 will get the first domain, teamserver1 and gophish1 will get the second domain, and so on.  If there are more Teamserver or Gophish instances than email-sending domains, the domains in the list will be reused in a wrap-around fashion. For example, if there are three Teamservers and only two email-sending domains, teamserver0 will get the first domain, teamserver1 will get the second domain, and teamserver2 will wrap-around back to using the first domain. | `list(string)` | ```[ "example.com" ]``` | no |
 | guac\_connection\_setup\_path | The full path to the dbinit directory where initialization files must be stored in order to work properly. (e.g. "/var/guacamole/dbinit") | `string` | `"/var/guacamole/dbinit"` | no |
@@ -500,6 +503,7 @@ the COOL environment.
 | debian\_desktop\_instance\_profile | The instance profile for the Debian desktop instances. |
 | debian\_desktop\_instances | The Debian desktop instances. |
 | debian\_desktop\_security\_group | The security group for the Debian desktop instances. |
+| efs\_access\_points | The access points to control file-system access to the EFS file share. |
 | efs\_client\_security\_group | A security group that should be applied to all instances that will mount the EFS file share. |
 | efs\_mount\_targets | The mount targets for the EFS file share. |
 | email\_sending\_domain\_certreadroles | The IAM roles that allow for reading the certificate for each email-sending domain. |

--- a/assessorportal_cloud_init.tf
+++ b/assessorportal_cloud_init.tf
@@ -16,6 +16,8 @@ data "cloudinit_config" "assessorportal_cloud_init_tasks" {
   part {
     content = templatefile(
       "${path.module}/cloud-init/efs-mount.tpl.yml", {
+        # Use the access point that corresponds with the EFS mount target used
+        efs_ap_id = aws_efs_access_point.access_point[var.private_subnet_cidr_blocks[0]].id
         # Just mount the EFS mount target in the first private subnet
         efs_id      = aws_efs_mount_target.target[var.private_subnet_cidr_blocks[0]].file_system_id
         group       = var.efs_users_group_name

--- a/cloud-init/efs-mount.tpl.yml
+++ b/cloud-init/efs-mount.tpl.yml
@@ -7,4 +7,5 @@ runcmd:
 
 # Add an fstab entry for the EFS mount
 mounts:
-  - ["${efs_id}:/", "${mount_point}", efs, "_netdev,iam,nofail,tls", "0", "0"]
+  # yamllint disable-line rule:line-length
+  - ["${efs_id}:/", "${mount_point}", efs, "_netdev,iam,nofail,tls,accesspoint=${efs_ap_id}", "0", "0"]

--- a/efs.tf
+++ b/efs.tf
@@ -25,6 +25,26 @@ resource "aws_efs_mount_target" "target" {
   security_groups = [aws_security_group.efs_mount_target.id]
 }
 
+# EFS access points for EFS mount targets
+resource "aws_efs_access_point" "access_point" {
+  provider = aws.provisionassessment
+  # Right now the private subnets are not distributed across AZs, and
+  # there can only be a single mount target per EFS per AZ.  As a
+  # result, we need only create one access point.  Once the private
+  # subnets are properly distributed we can create additional access
+  # points for each mount target.
+  #
+  # for_each = toset(var.private_subnet_cidr_blocks)
+  for_each = toset([var.private_subnet_cidr_blocks[0]])
+
+  file_system_id = aws_efs_mount_target.target[var.private_subnet_cidr_blocks[0]].file_system_id
+
+  posix_user {
+    gid = var.efs_access_point_gid
+    uid = var.efs_access_point_uid
+  }
+}
+
 # EFS security group
 resource "aws_security_group" "efs_mount_target" {
   provider = aws.provisionassessment

--- a/efs_mount_policy.tf
+++ b/efs_mount_policy.tf
@@ -9,9 +9,10 @@ data "aws_iam_policy_document" "efs_mount_policy_doc" {
     ]
     effect = "Allow"
     resources = [
-      # Allow mounting of the EFS mount target in the first private
-      # subnet
-      aws_efs_mount_target.target[var.private_subnet_cidr_blocks[0]].file_system_arn
+      # Allow mounting of the EFS access point and mount target in the first
+      # private subnet
+      aws_efs_access_point.access_point[var.private_subnet_cidr_blocks[0]].arn,
+      aws_efs_mount_target.target[var.private_subnet_cidr_blocks[0]].file_system_arn,
     ]
   }
 }

--- a/examples/use-terraformer-instance/teamserver_cloud_init.tf
+++ b/examples/use-terraformer-instance/teamserver_cloud_init.tf
@@ -21,6 +21,8 @@ data "cloudinit_config" "teamserver_cloud_init_tasks" {
   part {
     content = templatefile(
       "${path.module}/../../cloud-init/efs-mount.tpl.yml", {
+        # Use the access point that corresponds with the EFS mount target used
+        efs_ap_id = data.terraform_remote_state.cool_assessment_terraform.outputs.efs_access_points[data.terraform_remote_state.cool_assessment_terraform.outputs.private_subnet_cidr_blocks[0]].id
         # Just mount the EFS mount target in the first private subnet
         efs_id      = data.terraform_remote_state.cool_assessment_terraform.outputs.efs_mount_targets[data.terraform_remote_state.cool_assessment_terraform.outputs.private_subnet_cidr_blocks[0]].file_system_id
         group       = var.efs_mount_point_group

--- a/gophish_cloud_init.tf
+++ b/gophish_cloud_init.tf
@@ -22,6 +22,8 @@ data "cloudinit_config" "gophish_cloud_init_tasks" {
   part {
     content = templatefile(
       "${path.module}/cloud-init/efs-mount.tpl.yml", {
+        # Use the access point that corresponds with the EFS mount target used
+        efs_ap_id = aws_efs_access_point.access_point[var.private_subnet_cidr_blocks[0]].id
         # Just mount the EFS mount target in the first private subnet
         efs_id      = aws_efs_mount_target.target[var.private_subnet_cidr_blocks[0]].file_system_id
         group       = var.efs_users_group_name

--- a/kali_cloud_init.tf
+++ b/kali_cloud_init.tf
@@ -14,6 +14,8 @@ data "cloudinit_config" "kali_cloud_init_tasks" {
   part {
     content = templatefile(
       "${path.module}/cloud-init/efs-mount.tpl.yml", {
+        # Use the access point that corresponds with the EFS mount target used
+        efs_ap_id = aws_efs_access_point.access_point[var.private_subnet_cidr_blocks[0]].id
         # Just mount the EFS mount target in the first private subnet
         efs_id      = aws_efs_mount_target.target[var.private_subnet_cidr_blocks[0]].file_system_id
         group       = var.efs_users_group_name

--- a/outputs.tf
+++ b/outputs.tf
@@ -48,6 +48,11 @@ output "debian_desktop_security_group" {
   description = "The security group for the Debian desktop instances."
 }
 
+output "efs_access_points" {
+  value       = aws_efs_access_point.access_point
+  description = "The access points to control file-system access to the EFS file share."
+}
+
 output "efs_client_security_group" {
   value       = aws_security_group.efs_client
   description = "A security group that should be applied to all instances that will mount the EFS file share."

--- a/provisionassessment_policy.tf
+++ b/provisionassessment_policy.tf
@@ -86,10 +86,13 @@ data "aws_iam_policy_document" "provisionassessment_policy_doc" {
 
   statement {
     actions = [
+      "elasticfilesystem:CreateAccessPoint",
       "elasticfilesystem:CreateFileSystem",
       "elasticfilesystem:CreateMountTarget",
+      "elasticfilesystem:DeleteAccessPoint",
       "elasticfilesystem:DeleteFileSystem",
       "elasticfilesystem:DeleteMountTarget",
+      "elasticfilesystem:DescribeAccessPoints",
       "elasticfilesystem:DescribeFileSystems",
       "elasticfilesystem:DescribeLifecycleConfiguration",
       "elasticfilesystem:DescribeMountTargets",

--- a/samba_cloud_init.tf
+++ b/samba_cloud_init.tf
@@ -14,6 +14,8 @@ data "cloudinit_config" "samba_cloud_init_tasks" {
   part {
     content = templatefile(
       "${path.module}/cloud-init/efs-mount.tpl.yml", {
+        # Use the access point that corresponds with the EFS mount target used
+        efs_ap_id = aws_efs_access_point.access_point[var.private_subnet_cidr_blocks[0]].id
         # Just mount the EFS mount target in the first private subnet
         efs_id      = aws_efs_mount_target.target[var.private_subnet_cidr_blocks[0]].file_system_id
         group       = var.efs_users_group_name

--- a/teamserver_cloud_init.tf
+++ b/teamserver_cloud_init.tf
@@ -23,6 +23,8 @@ data "cloudinit_config" "teamserver_cloud_init_tasks" {
   part {
     content = templatefile(
       "${path.module}/cloud-init/efs-mount.tpl.yml", {
+        # Use the access point that corresponds with the EFS mount target used
+        efs_ap_id = aws_efs_access_point.access_point[var.private_subnet_cidr_blocks[0]].id
         # Just mount the EFS mount target in the first private subnet
         efs_id      = aws_efs_mount_target.target[var.private_subnet_cidr_blocks[0]].file_system_id
         group       = var.efs_users_group_name

--- a/terraformer_cloud_init.tf
+++ b/terraformer_cloud_init.tf
@@ -14,6 +14,8 @@ data "cloudinit_config" "terraformer_cloud_init_tasks" {
   part {
     content = templatefile(
       "${path.module}/cloud-init/efs-mount.tpl.yml", {
+        # Use the access point that corresponds with the EFS mount target used
+        efs_ap_id = aws_efs_access_point.access_point[var.private_subnet_cidr_blocks[0]].id
         # Just mount the EFS mount target in the first private subnet
         efs_id      = aws_efs_mount_target.target[var.private_subnet_cidr_blocks[0]].file_system_id
         group       = var.efs_users_group_name

--- a/variables.tf
+++ b/variables.tf
@@ -67,6 +67,18 @@ variable "dns_ttl" {
   default     = 60
 }
 
+variable "efs_access_point_gid" {
+  type        = number
+  description = "The group ID that should be used for file-system access to the EFS share (e.g. 2048).  Note that this value should match the GID of any group given ownership of the EFS share mount point."
+  default     = 2048
+}
+
+variable "efs_access_point_uid" {
+  type        = number
+  description = "The user ID that should be used for file-system access to the EFS share (e.g. 2048).  Note that this value should match the UID of any user given ownership of the EFS share mount point."
+  default     = 2048
+}
+
 variable "efs_users_group_name" {
   type        = string
   description = "The name of the POSIX group that should have ownership of a mounted EFS share (e.g. \"efs_users\")."


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds an [EFS access point](https://docs.aws.amazon.com/efs/latest/ug/efs-access-points.html) for each [EFS mount target](https://docs.aws.amazon.com/efs/latest/ug/accessing-fs.html) (currently only one). The access point is configured to enforce the UID and GID for file-system access to the EFS share.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Right now any resources in the EFS share will use the UID/GID of whatever user is creating them. This means that if a user on a Kali system adds resources to the EFS share as the `root` user they will have the the UID/GID of the `root` user. This can cause problems for interacting with resource on the EFS share for other systems (most notably Windows instances). Using the access point will ensure that any resources created in the EFS share have the UID of the `vnc`/`smbguest` users and the GID of the `efs_users` group. This will ensure that resource access is consistent and available for all users of the EFS share.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I applied this in my testing environment and everything worked as expected.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots ##

![image](https://user-images.githubusercontent.com/50747025/145494654-78a277f3-4484-4797-89df-f5aa5caec64a.png)
![image](https://user-images.githubusercontent.com/50747025/145494701-6de67edc-3dfd-46d7-962c-452e932bd5a1.png)
<!-- Remove this section and header if not needed -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
