### PR TITLE
Allow more access between Kali and Teamserver instances

### DIFF
--- a/kali_sg.tf
+++ b/kali_sg.tf
@@ -68,7 +68,7 @@ resource "aws_security_group_rule" "ingress_from_anywhere_to_kali_via_allowed_po
 # Allow access between Kali and Teamserver instances on ports
 # 5000-5999 (TCP and UDP).  This port range was requested for use by
 # assessment operators in cisagov/cool-system-internal#79.
-resource "aws_security_group_rule" "kali_egress_to_teamserver_instances" {
+resource "aws_security_group_rule" "kali_egress_to_teamserver_instances_via_5000_to_5999" {
   provider = aws.provisionassessment
   for_each = toset(["tcp", "udp"])
 
@@ -79,7 +79,7 @@ resource "aws_security_group_rule" "kali_egress_to_teamserver_instances" {
   from_port                = 5000
   to_port                  = 5999
 }
-resource "aws_security_group_rule" "kali_ingress_from_teamserver_instances" {
+resource "aws_security_group_rule" "kali_ingress_from_teamserver_instances_via_5000_to_5999" {
   provider = aws.provisionassessment
   for_each = toset(["tcp", "udp"])
 

--- a/kali_sg.tf
+++ b/kali_sg.tf
@@ -65,7 +65,9 @@ resource "aws_security_group_rule" "ingress_from_anywhere_to_kali_via_allowed_po
   to_port           = each.value["to_port"]
 }
 
-# Allow unfettered access between Kali and Teamserver instances
+# Allow access between Kali and Teamserver instances on ports
+# 5000-5999 (TCP and UDP).  This port range was requested for use by
+# assessment operators in cisagov/cool-system-internal#79.
 resource "aws_security_group_rule" "kali_egress_to_teamserver_instances" {
   provider = aws.provisionassessment
   for_each = toset(["tcp", "udp"])

--- a/kali_sg.tf
+++ b/kali_sg.tf
@@ -65,6 +65,30 @@ resource "aws_security_group_rule" "ingress_from_anywhere_to_kali_via_allowed_po
   to_port           = each.value["to_port"]
 }
 
+# Allow unfettered access between Kali and Teamserver instances
+resource "aws_security_group_rule" "kali_egress_to_teamserver_instances" {
+  provider = aws.provisionassessment
+  for_each = toset(["tcp", "udp"])
+
+  security_group_id        = aws_security_group.kali.id
+  type                     = "egress"
+  protocol                 = each.key
+  source_security_group_id = aws_security_group.teamserver.id
+  from_port                = 5000
+  to_port                  = 5999
+}
+resource "aws_security_group_rule" "kali_ingress_from_teamserver_instances" {
+  provider = aws.provisionassessment
+  for_each = toset(["tcp", "udp"])
+
+  security_group_id        = aws_security_group.kali.id
+  type                     = "ingress"
+  protocol                 = each.key
+  source_security_group_id = aws_security_group.teamserver.id
+  from_port                = 5000
+  to_port                  = 5999
+}
+
 # Allow unfettered access between Kali and Windows instances
 resource "aws_security_group_rule" "kali_egress_to_windows_instances" {
   provider = aws.provisionassessment

--- a/teamserver_sg.tf
+++ b/teamserver_sg.tf
@@ -81,3 +81,27 @@ resource "aws_security_group_rule" "ingress_from_anywhere_to_teamserver_via_allo
   from_port         = each.value["from_port"]
   to_port           = each.value["to_port"]
 }
+
+# Allow unfettered access between Teamserver and Kali instances
+resource "aws_security_group_rule" "teamserver_egress_to_kali_instances" {
+  provider = aws.provisionassessment
+  for_each = toset(["tcp", "udp"])
+
+  security_group_id        = aws_security_group.teamserver.id
+  type                     = "egress"
+  protocol                 = each.key
+  source_security_group_id = aws_security_group.kali.id
+  from_port                = 5000
+  to_port                  = 5999
+}
+resource "aws_security_group_rule" "teamserver_ingress_from_kali_instances" {
+  provider = aws.provisionassessment
+  for_each = toset(["tcp", "udp"])
+
+  security_group_id        = aws_security_group.teamserver.id
+  type                     = "ingress"
+  protocol                 = each.key
+  source_security_group_id = aws_security_group.kali.id
+  from_port                = 5000
+  to_port                  = 5999
+}

--- a/teamserver_sg.tf
+++ b/teamserver_sg.tf
@@ -82,7 +82,9 @@ resource "aws_security_group_rule" "ingress_from_anywhere_to_teamserver_via_allo
   to_port           = each.value["to_port"]
 }
 
-# Allow unfettered access between Teamserver and Kali instances
+# Allow access between Teamserver and Kali instances on ports
+# 5000-5999 (TCP and UDP).  This port range was requested for use by
+# assessment operators in cisagov/cool-system-internal#79.
 resource "aws_security_group_rule" "teamserver_egress_to_kali_instances" {
   provider = aws.provisionassessment
   for_each = toset(["tcp", "udp"])

--- a/teamserver_sg.tf
+++ b/teamserver_sg.tf
@@ -85,7 +85,7 @@ resource "aws_security_group_rule" "ingress_from_anywhere_to_teamserver_via_allo
 # Allow access between Teamserver and Kali instances on ports
 # 5000-5999 (TCP and UDP).  This port range was requested for use by
 # assessment operators in cisagov/cool-system-internal#79.
-resource "aws_security_group_rule" "teamserver_egress_to_kali_instances" {
+resource "aws_security_group_rule" "teamserver_egress_to_kali_instances_via_5000_to_5999" {
   provider = aws.provisionassessment
   for_each = toset(["tcp", "udp"])
 
@@ -96,7 +96,7 @@ resource "aws_security_group_rule" "teamserver_egress_to_kali_instances" {
   from_port                = 5000
   to_port                  = 5999
 }
-resource "aws_security_group_rule" "teamserver_ingress_from_kali_instances" {
+resource "aws_security_group_rule" "teamserver_ingress_from_kali_instances_via_5000_to_5999" {
   provider = aws.provisionassessment
   for_each = toset(["tcp", "udp"])
 


### PR DESCRIPTION
## 🗣 Description ##

This pull request allows full TCP and UDP access between Kali and Teamserver instances on ports 5000-5999.

## 💭 Motivation and context ##

Resolves cisagov/cool-system-internal#79.

## 🧪 Testing ##

Automated testing passes.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
