### PR TITLE
Add ec2:ModifyAddressAttribute to ProvisionAssessment policy

### DIFF
--- a/provisionassessment_policy.tf
+++ b/provisionassessment_policy.tf
@@ -55,6 +55,7 @@ data "aws_iam_policy_document" "provisionassessment_policy_doc" {
       "ec2:DisassociateVpcCidrBlock",
       "ec2:GetTransitGatewayRouteTableAssociations",
       "ec2:GetTransitGatewayRouteTablePropagations",
+      "ec2:ModifyAddressAttribute",
       "ec2:ModifyInstanceAttribute",
       "ec2:ModifyInstanceMetadataOptions",
       "ec2:ModifyNetworkInterfaceAttribute",


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
This PR adds the `ec2:ModifyAddressAttribute` to the IAM policy that allows provisioning of the resources required in an assessment account.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This will enable users of this policy to modify attributes of EC2 addresses.  Our initial use case is to be able to set up a PTR record for an elastic IP via a command like this:  
```console
aws ec2 modify-address-attribute --allocation-id eipalloc-0123456789abcdefg --domain-name example.gov
```

To check the results of the command above, one would do:
```console
aws ec2 describe-addresses-attribute --allocation-ids eipalloc-0123456789abcdefg --attribute domain-name
```

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I confirmed that adding this permission in a test account enabled me to successfully run an `aws ec2 modify-address-attribute` command.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
