### PR TITLE
Add standard CloudWatch instance alarms for all instance types

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 # These owners will be the default owners for everything in the
 # repo. Unless a later match takes precedence, these owners will be
 # requested for review when someone opens a pull request.
-* @dav3r @felddy @jsf9k
+* @dav3r @felddy @jsf9k @mcdonnnj
 
 # These folks own any files in the .github directory at the root of
 # the repository and any of its subdirectories.

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ the COOL environment.
 | cw\_alarms\_samba | github.com/cisagov/instance-cw-alarms-tf-module | n/a |
 | cw\_alarms\_teamserver | github.com/cisagov/instance-cw-alarms-tf-module | n/a |
 | cw\_alarms\_terraformer | github.com/cisagov/instance-cw-alarms-tf-module | n/a |
+| cw\_alarms\_windows | github.com/cisagov/instance-cw-alarms-tf-module | n/a |
 | email\_sending\_domain\_certreadrole | github.com/cisagov/cert-read-role-tf-module | n/a |
 | guacamole\_certreadrole | github.com/cisagov/cert-read-role-tf-module | n/a |
 | read\_terraform\_state | github.com/cisagov/terraform-state-read-role-tf-module | n/a |

--- a/README.md
+++ b/README.md
@@ -94,6 +94,16 @@ the COOL environment.
 
 | Name | Source | Version |
 |------|--------|---------|
+| cw\_alarms\_assessor\_portal | github.com/cisagov/instance-cw-alarms-tf-module | first-commits |
+| cw\_alarms\_debiandesktop | github.com/cisagov/instance-cw-alarms-tf-module | first-commits |
+| cw\_alarms\_gophish | github.com/cisagov/instance-cw-alarms-tf-module | first-commits |
+| cw\_alarms\_guacamole | github.com/cisagov/instance-cw-alarms-tf-module | first-commits |
+| cw\_alarms\_kali | github.com/cisagov/instance-cw-alarms-tf-module | first-commits |
+| cw\_alarms\_nessus | github.com/cisagov/instance-cw-alarms-tf-module | first-commits |
+| cw\_alarms\_pentestportal | github.com/cisagov/instance-cw-alarms-tf-module | first-commits |
+| cw\_alarms\_samba | github.com/cisagov/instance-cw-alarms-tf-module | first-commits |
+| cw\_alarms\_teamserver | github.com/cisagov/instance-cw-alarms-tf-module | first-commits |
+| cw\_alarms\_terraformer | github.com/cisagov/instance-cw-alarms-tf-module | first-commits |
 | email\_sending\_domain\_certreadrole | github.com/cisagov/cert-read-role-tf-module | n/a |
 | guacamole\_certreadrole | github.com/cisagov/cert-read-role-tf-module | n/a |
 | read\_terraform\_state | github.com/cisagov/terraform-state-read-role-tf-module | n/a |

--- a/README.md
+++ b/README.md
@@ -94,16 +94,16 @@ the COOL environment.
 
 | Name | Source | Version |
 |------|--------|---------|
-| cw\_alarms\_assessor\_portal | github.com/cisagov/instance-cw-alarms-tf-module | first-commits |
-| cw\_alarms\_debiandesktop | github.com/cisagov/instance-cw-alarms-tf-module | first-commits |
-| cw\_alarms\_gophish | github.com/cisagov/instance-cw-alarms-tf-module | first-commits |
-| cw\_alarms\_guacamole | github.com/cisagov/instance-cw-alarms-tf-module | first-commits |
-| cw\_alarms\_kali | github.com/cisagov/instance-cw-alarms-tf-module | first-commits |
-| cw\_alarms\_nessus | github.com/cisagov/instance-cw-alarms-tf-module | first-commits |
-| cw\_alarms\_pentestportal | github.com/cisagov/instance-cw-alarms-tf-module | first-commits |
-| cw\_alarms\_samba | github.com/cisagov/instance-cw-alarms-tf-module | first-commits |
-| cw\_alarms\_teamserver | github.com/cisagov/instance-cw-alarms-tf-module | first-commits |
-| cw\_alarms\_terraformer | github.com/cisagov/instance-cw-alarms-tf-module | first-commits |
+| cw\_alarms\_assessor\_portal | github.com/cisagov/instance-cw-alarms-tf-module | n/a |
+| cw\_alarms\_debiandesktop | github.com/cisagov/instance-cw-alarms-tf-module | n/a |
+| cw\_alarms\_gophish | github.com/cisagov/instance-cw-alarms-tf-module | n/a |
+| cw\_alarms\_guacamole | github.com/cisagov/instance-cw-alarms-tf-module | n/a |
+| cw\_alarms\_kali | github.com/cisagov/instance-cw-alarms-tf-module | n/a |
+| cw\_alarms\_nessus | github.com/cisagov/instance-cw-alarms-tf-module | n/a |
+| cw\_alarms\_pentestportal | github.com/cisagov/instance-cw-alarms-tf-module | n/a |
+| cw\_alarms\_samba | github.com/cisagov/instance-cw-alarms-tf-module | n/a |
+| cw\_alarms\_teamserver | github.com/cisagov/instance-cw-alarms-tf-module | n/a |
+| cw\_alarms\_terraformer | github.com/cisagov/instance-cw-alarms-tf-module | n/a |
 | email\_sending\_domain\_certreadrole | github.com/cisagov/cert-read-role-tf-module | n/a |
 | guacamole\_certreadrole | github.com/cisagov/cert-read-role-tf-module | n/a |
 | read\_terraform\_state | github.com/cisagov/terraform-state-read-role-tf-module | n/a |

--- a/assessorportal_ec2.tf
+++ b/assessorportal_ec2.tf
@@ -97,3 +97,16 @@ resource "aws_volume_attachment" "assessorportal_docker" {
   instance_id = aws_instance.assessorportal[count.index].id
   volume_id   = aws_ebs_volume.assessorportal_docker[count.index].id
 }
+
+# CloudWatch alarms for the Assessor Portal instances
+module "cw_alarms_assessor_portal" {
+  providers = {
+    aws = aws.provisionassessment
+  }
+  source = "github.com/cisagov/instance-cw-alarms-tf-module?ref=first-commits"
+
+  alarm_actions             = [data.terraform_remote_state.dynamic_assessment.outputs.cw_alarm_sns_topic.arn]
+  instance_ids              = [for instance in aws_instance.assessorportal : instance.id]
+  insufficient_data_actions = [data.terraform_remote_state.dynamic_assessment.outputs.cw_alarm_sns_topic.arn]
+  ok_actions                = [data.terraform_remote_state.dynamic_assessment.outputs.cw_alarm_sns_topic.arn]
+}

--- a/assessorportal_ec2.tf
+++ b/assessorportal_ec2.tf
@@ -103,7 +103,7 @@ module "cw_alarms_assessor_portal" {
   providers = {
     aws = aws.provisionassessment
   }
-  source = "github.com/cisagov/instance-cw-alarms-tf-module?ref=first-commits"
+  source = "github.com/cisagov/instance-cw-alarms-tf-module"
 
   alarm_actions             = [data.terraform_remote_state.dynamic_assessment.outputs.cw_alarm_sns_topic.arn]
   instance_ids              = [for instance in aws_instance.assessorportal : instance.id]

--- a/debiandesktop_ec2.tf
+++ b/debiandesktop_ec2.tf
@@ -70,3 +70,16 @@ resource "aws_instance" "debiandesktop" {
     Name = format("DebianDesktop%d", count.index)
   })
 }
+
+# CloudWatch alarms for the Debian Desktop instances
+module "cw_alarms_debiandesktop" {
+  providers = {
+    aws = aws.provisionassessment
+  }
+  source = "github.com/cisagov/instance-cw-alarms-tf-module?ref=first-commits"
+
+  alarm_actions             = [data.terraform_remote_state.dynamic_assessment.outputs.cw_alarm_sns_topic.arn]
+  instance_ids              = [for instance in aws_instance.debiandesktop : instance.id]
+  insufficient_data_actions = [data.terraform_remote_state.dynamic_assessment.outputs.cw_alarm_sns_topic.arn]
+  ok_actions                = [data.terraform_remote_state.dynamic_assessment.outputs.cw_alarm_sns_topic.arn]
+}

--- a/debiandesktop_ec2.tf
+++ b/debiandesktop_ec2.tf
@@ -76,7 +76,7 @@ module "cw_alarms_debiandesktop" {
   providers = {
     aws = aws.provisionassessment
   }
-  source = "github.com/cisagov/instance-cw-alarms-tf-module?ref=first-commits"
+  source = "github.com/cisagov/instance-cw-alarms-tf-module"
 
   alarm_actions             = [data.terraform_remote_state.dynamic_assessment.outputs.cw_alarm_sns_topic.arn]
   instance_ids              = [for instance in aws_instance.debiandesktop : instance.id]

--- a/gophish_ec2.tf
+++ b/gophish_ec2.tf
@@ -122,3 +122,16 @@ resource "aws_volume_attachment" "gophish_docker" {
   instance_id = aws_instance.gophish[count.index].id
   volume_id   = aws_ebs_volume.gophish_docker[count.index].id
 }
+
+# CloudWatch alarms for the Gophish instances
+module "cw_alarms_gophish" {
+  providers = {
+    aws = aws.provisionassessment
+  }
+  source = "github.com/cisagov/instance-cw-alarms-tf-module?ref=first-commits"
+
+  alarm_actions             = [data.terraform_remote_state.dynamic_assessment.outputs.cw_alarm_sns_topic.arn]
+  instance_ids              = [for instance in aws_instance.gophish : instance.id]
+  insufficient_data_actions = [data.terraform_remote_state.dynamic_assessment.outputs.cw_alarm_sns_topic.arn]
+  ok_actions                = [data.terraform_remote_state.dynamic_assessment.outputs.cw_alarm_sns_topic.arn]
+}

--- a/gophish_ec2.tf
+++ b/gophish_ec2.tf
@@ -128,7 +128,7 @@ module "cw_alarms_gophish" {
   providers = {
     aws = aws.provisionassessment
   }
-  source = "github.com/cisagov/instance-cw-alarms-tf-module?ref=first-commits"
+  source = "github.com/cisagov/instance-cw-alarms-tf-module"
 
   alarm_actions             = [data.terraform_remote_state.dynamic_assessment.outputs.cw_alarm_sns_topic.arn]
   instance_ids              = [for instance in aws_instance.gophish : instance.id]

--- a/guacamole_ec2.tf
+++ b/guacamole_ec2.tf
@@ -82,3 +82,16 @@ resource "aws_instance" "guacamole" {
     Name = "Guacamole"
   })
 }
+
+# CloudWatch alarms for the Guacamole instances
+module "cw_alarms_guacamole" {
+  providers = {
+    aws = aws.provisionassessment
+  }
+  source = "github.com/cisagov/instance-cw-alarms-tf-module?ref=first-commits"
+
+  alarm_actions             = [data.terraform_remote_state.dynamic_assessment.outputs.cw_alarm_sns_topic.arn]
+  instance_ids              = [aws_instance.guacamole.id]
+  insufficient_data_actions = [data.terraform_remote_state.dynamic_assessment.outputs.cw_alarm_sns_topic.arn]
+  ok_actions                = [data.terraform_remote_state.dynamic_assessment.outputs.cw_alarm_sns_topic.arn]
+}

--- a/guacamole_ec2.tf
+++ b/guacamole_ec2.tf
@@ -88,7 +88,7 @@ module "cw_alarms_guacamole" {
   providers = {
     aws = aws.provisionassessment
   }
-  source = "github.com/cisagov/instance-cw-alarms-tf-module?ref=first-commits"
+  source = "github.com/cisagov/instance-cw-alarms-tf-module"
 
   alarm_actions             = [data.terraform_remote_state.dynamic_assessment.outputs.cw_alarm_sns_topic.arn]
   instance_ids              = [aws_instance.guacamole.id]

--- a/kali_ec2.tf
+++ b/kali_ec2.tf
@@ -96,7 +96,7 @@ module "cw_alarms_kali" {
   providers = {
     aws = aws.provisionassessment
   }
-  source = "github.com/cisagov/instance-cw-alarms-tf-module?ref=first-commits"
+  source = "github.com/cisagov/instance-cw-alarms-tf-module"
 
   alarm_actions             = [data.terraform_remote_state.dynamic_assessment.outputs.cw_alarm_sns_topic.arn]
   instance_ids              = [for instance in aws_instance.kali : instance.id]

--- a/kali_ec2.tf
+++ b/kali_ec2.tf
@@ -90,3 +90,16 @@ resource "aws_eip_association" "kali" {
   instance_id   = aws_instance.kali[count.index].id
   allocation_id = aws_eip.kali[count.index].id
 }
+
+# CloudWatch alarms for the Kali instances
+module "cw_alarms_kali" {
+  providers = {
+    aws = aws.provisionassessment
+  }
+  source = "github.com/cisagov/instance-cw-alarms-tf-module?ref=first-commits"
+
+  alarm_actions             = [data.terraform_remote_state.dynamic_assessment.outputs.cw_alarm_sns_topic.arn]
+  instance_ids              = [for instance in aws_instance.kali : instance.id]
+  insufficient_data_actions = [data.terraform_remote_state.dynamic_assessment.outputs.cw_alarm_sns_topic.arn]
+  ok_actions                = [data.terraform_remote_state.dynamic_assessment.outputs.cw_alarm_sns_topic.arn]
+}

--- a/nessus_ec2.tf
+++ b/nessus_ec2.tf
@@ -109,7 +109,7 @@ module "cw_alarms_nessus" {
   providers = {
     aws = aws.provisionassessment
   }
-  source = "github.com/cisagov/instance-cw-alarms-tf-module?ref=first-commits"
+  source = "github.com/cisagov/instance-cw-alarms-tf-module"
 
   alarm_actions             = [data.terraform_remote_state.dynamic_assessment.outputs.cw_alarm_sns_topic.arn]
   instance_ids              = [for instance in aws_instance.nessus : instance.id]

--- a/nessus_ec2.tf
+++ b/nessus_ec2.tf
@@ -103,3 +103,16 @@ resource "aws_eip_association" "nessus" {
   instance_id   = aws_instance.nessus[count.index].id
   allocation_id = aws_eip.nessus[count.index].id
 }
+
+# CloudWatch alarms for the Nessus instances
+module "cw_alarms_nessus" {
+  providers = {
+    aws = aws.provisionassessment
+  }
+  source = "github.com/cisagov/instance-cw-alarms-tf-module?ref=first-commits"
+
+  alarm_actions             = [data.terraform_remote_state.dynamic_assessment.outputs.cw_alarm_sns_topic.arn]
+  instance_ids              = [for instance in aws_instance.nessus : instance.id]
+  insufficient_data_actions = [data.terraform_remote_state.dynamic_assessment.outputs.cw_alarm_sns_topic.arn]
+  ok_actions                = [data.terraform_remote_state.dynamic_assessment.outputs.cw_alarm_sns_topic.arn]
+}

--- a/pentestportal_ec2.tf
+++ b/pentestportal_ec2.tf
@@ -91,3 +91,16 @@ resource "aws_eip_association" "pentestportal" {
   instance_id   = aws_instance.pentestportal[count.index].id
   allocation_id = aws_eip.pentestportal[count.index].id
 }
+
+# CloudWatch alarms for the pentest portal instances
+module "cw_alarms_pentestportal" {
+  providers = {
+    aws = aws.provisionassessment
+  }
+  source = "github.com/cisagov/instance-cw-alarms-tf-module?ref=first-commits"
+
+  alarm_actions             = [data.terraform_remote_state.dynamic_assessment.outputs.cw_alarm_sns_topic.arn]
+  instance_ids              = [for instance in aws_instance.pentestportal : instance.id]
+  insufficient_data_actions = [data.terraform_remote_state.dynamic_assessment.outputs.cw_alarm_sns_topic.arn]
+  ok_actions                = [data.terraform_remote_state.dynamic_assessment.outputs.cw_alarm_sns_topic.arn]
+}

--- a/pentestportal_ec2.tf
+++ b/pentestportal_ec2.tf
@@ -97,7 +97,7 @@ module "cw_alarms_pentestportal" {
   providers = {
     aws = aws.provisionassessment
   }
-  source = "github.com/cisagov/instance-cw-alarms-tf-module?ref=first-commits"
+  source = "github.com/cisagov/instance-cw-alarms-tf-module"
 
   alarm_actions             = [data.terraform_remote_state.dynamic_assessment.outputs.cw_alarm_sns_topic.arn]
   instance_ids              = [for instance in aws_instance.pentestportal : instance.id]

--- a/provisionassessment_policy.tf
+++ b/provisionassessment_policy.tf
@@ -6,6 +6,18 @@
 data "aws_iam_policy_document" "provisionassessment_policy_doc" {
   statement {
     actions = [
+      "cloudwatch:DeleteAlarms",
+      "cloudwatch:ListTagsForResource",
+      "cloudwatch:PutMetricAlarm",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+
+  statement {
+    actions = [
       "ec2:AllocateAddress",
       "ec2:AssociateAddress",
       "ec2:AssociateDhcpOptions",

--- a/samba_ec2.tf
+++ b/samba_ec2.tf
@@ -82,7 +82,7 @@ module "cw_alarms_samba" {
   providers = {
     aws = aws.provisionassessment
   }
-  source = "github.com/cisagov/instance-cw-alarms-tf-module?ref=first-commits"
+  source = "github.com/cisagov/instance-cw-alarms-tf-module"
 
   alarm_actions             = [data.terraform_remote_state.dynamic_assessment.outputs.cw_alarm_sns_topic.arn]
   instance_ids              = [for instance in aws_instance.samba : instance.id]

--- a/samba_ec2.tf
+++ b/samba_ec2.tf
@@ -76,3 +76,16 @@ resource "aws_instance" "samba" {
     Name = format("Samba%d", count.index)
   })
 }
+
+# CloudWatch alarms for the Samba instances
+module "cw_alarms_samba" {
+  providers = {
+    aws = aws.provisionassessment
+  }
+  source = "github.com/cisagov/instance-cw-alarms-tf-module?ref=first-commits"
+
+  alarm_actions             = [data.terraform_remote_state.dynamic_assessment.outputs.cw_alarm_sns_topic.arn]
+  instance_ids              = [for instance in aws_instance.samba : instance.id]
+  insufficient_data_actions = [data.terraform_remote_state.dynamic_assessment.outputs.cw_alarm_sns_topic.arn]
+  ok_actions                = [data.terraform_remote_state.dynamic_assessment.outputs.cw_alarm_sns_topic.arn]
+}

--- a/teamserver_ec2.tf
+++ b/teamserver_ec2.tf
@@ -109,7 +109,7 @@ module "cw_alarms_teamserver" {
   providers = {
     aws = aws.provisionassessment
   }
-  source = "github.com/cisagov/instance-cw-alarms-tf-module?ref=first-commits"
+  source = "github.com/cisagov/instance-cw-alarms-tf-module"
 
   alarm_actions             = [data.terraform_remote_state.dynamic_assessment.outputs.cw_alarm_sns_topic.arn]
   instance_ids              = [for instance in aws_instance.teamserver : instance.id]

--- a/teamserver_ec2.tf
+++ b/teamserver_ec2.tf
@@ -103,3 +103,16 @@ resource "aws_eip_association" "teamserver" {
   instance_id   = aws_instance.teamserver[count.index].id
   allocation_id = aws_eip.teamserver[count.index].id
 }
+
+# CloudWatch alarms for the teamserver instances
+module "cw_alarms_teamserver" {
+  providers = {
+    aws = aws.provisionassessment
+  }
+  source = "github.com/cisagov/instance-cw-alarms-tf-module?ref=first-commits"
+
+  alarm_actions             = [data.terraform_remote_state.dynamic_assessment.outputs.cw_alarm_sns_topic.arn]
+  instance_ids              = [for instance in aws_instance.teamserver : instance.id]
+  insufficient_data_actions = [data.terraform_remote_state.dynamic_assessment.outputs.cw_alarm_sns_topic.arn]
+  ok_actions                = [data.terraform_remote_state.dynamic_assessment.outputs.cw_alarm_sns_topic.arn]
+}

--- a/terraformer_ec2.tf
+++ b/terraformer_ec2.tf
@@ -78,7 +78,7 @@ module "cw_alarms_terraformer" {
   providers = {
     aws = aws.provisionassessment
   }
-  source = "github.com/cisagov/instance-cw-alarms-tf-module?ref=first-commits"
+  source = "github.com/cisagov/instance-cw-alarms-tf-module"
 
   alarm_actions             = [data.terraform_remote_state.dynamic_assessment.outputs.cw_alarm_sns_topic.arn]
   instance_ids              = [for instance in aws_instance.terraformer : instance.id]

--- a/terraformer_ec2.tf
+++ b/terraformer_ec2.tf
@@ -72,3 +72,16 @@ resource "aws_instance" "terraformer" {
     Name = format("Terraformer%d", count.index)
   })
 }
+
+# CloudWatch alarms for the Terraformer instances
+module "cw_alarms_terraformer" {
+  providers = {
+    aws = aws.provisionassessment
+  }
+  source = "github.com/cisagov/instance-cw-alarms-tf-module?ref=first-commits"
+
+  alarm_actions             = [data.terraform_remote_state.dynamic_assessment.outputs.cw_alarm_sns_topic.arn]
+  instance_ids              = [for instance in aws_instance.terraformer : instance.id]
+  insufficient_data_actions = [data.terraform_remote_state.dynamic_assessment.outputs.cw_alarm_sns_topic.arn]
+  ok_actions                = [data.terraform_remote_state.dynamic_assessment.outputs.cw_alarm_sns_topic.arn]
+}


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds a set of standard CloudWatch instance alarms for all instance types.

## 💭 Motivation and context ##

These alarms will notify us via email if any of the following should occur:
- Either of an instance's status checks (instance or system) fail
- Any IMDSv1 requests succeed
- CPU, memory, or disk utilization is high
- Any packets are queued and/or dropped because the a networking limitation was exceeded for the instance

## 🧪 Testing ##

All automated testing passes.  This code is also already applied to env6 in our COOL staging environment.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [x] Revert dependencies to default branches.