### PR TITLE
Add cloud-init code to preemptively set the hostname on all instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,10 +428,12 @@ the COOL environment.
 | [aws_ssm_parameter.samba_username](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 | [aws_ssm_parameter.vnc_username](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 | [cloudinit_config.assessorportal_cloud_init_tasks](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs/data-sources/config) | data source |
+| [cloudinit_config.debiandesktop_cloud_init_tasks](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs/data-sources/config) | data source |
 | [cloudinit_config.gophish_cloud_init_tasks](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs/data-sources/config) | data source |
 | [cloudinit_config.guacamole_cloud_init_tasks](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs/data-sources/config) | data source |
 | [cloudinit_config.kali_cloud_init_tasks](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs/data-sources/config) | data source |
 | [cloudinit_config.nessus_cloud_init_tasks](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs/data-sources/config) | data source |
+| [cloudinit_config.pentestportal_cloud_init_tasks](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs/data-sources/config) | data source |
 | [cloudinit_config.samba_cloud_init_tasks](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs/data-sources/config) | data source |
 | [cloudinit_config.teamserver_cloud_init_tasks](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs/data-sources/config) | data source |
 | [cloudinit_config.terraformer_cloud_init_tasks](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs/data-sources/config) | data source |
@@ -531,7 +533,7 @@ the COOL environment.
 | samba\_instances | The Samba file share server instances. |
 | samba\_server\_security\_group | The security group for the Samba file share server instances. |
 | scanner\_security\_group | A security group that should be applied to all instance types that perform scanning.  This security group allows egress to anywhere as well as ingress from anywhere via ICMP. |
-| ssm\_agent\_endpoint\_client\_security\_group | A security group for any instances that run the AWS SSM agent.  This security groups allows such instances to communicate with the VPC endpoints that are required by the AWS SSM agent. |
+| ssm\_agent\_endpoint\_client\_security\_group | A security group for any instances that run the AWS SSM agent.  This security group allows such instances to communicate with the VPC endpoints that are required by the AWS SSM agent. |
 | ssm\_endpoint\_client\_security\_group | A security group for any instances that wish to communicate with the SSM VPC endpoint. |
 | ssm\_session\_role | An IAM role that allows creation of SSM SessionManager sessions to any EC2 instance in this account. |
 | sts\_endpoint\_client\_security\_group | A security group for any instances that wish to communicate with the STS VPC endpoint. |

--- a/cloud-init/set-hostname.tpl.yml
+++ b/cloud-init/set-hostname.tpl.yml
@@ -1,0 +1,8 @@
+---
+
+# Set the hostname and FQDN
+#
+# For an explanation of these variables, see here:
+# https://cloudinit.readthedocs.io/en/latest/topics/modules.html#set-hostname
+fqdn: "${fqdn}"
+hostname: "${hostname}"

--- a/debiandesktop_cloud_init.tf
+++ b/debiandesktop_cloud_init.tf
@@ -1,7 +1,7 @@
-# cloud-init commands for configuring Assessor Portal instances
+# cloud-init commands for configuring Debian Desktop instances
 
-data "cloudinit_config" "assessorportal_cloud_init_tasks" {
-  count = lookup(var.operations_instance_counts, "assessorportal", 0)
+data "cloudinit_config" "debiandesktop_cloud_init_tasks" {
+  count = lookup(var.operations_instance_counts, "debiandesktop", 0)
 
   gzip          = true
   base64_encode = true
@@ -23,8 +23,8 @@ data "cloudinit_config" "assessorportal_cloud_init_tasks" {
       "${path.module}/cloud-init/set-hostname.tpl.yml", {
         # Note that the hostname here is identical to what is set in
         # the corresponding DNS A record.
-        fqdn     = "assessorportal${count.index}.${aws_route53_zone.assessment_private.name}"
-        hostname = "assessorportal${count.index}"
+        fqdn     = "debiandesktop${count.index}.${aws_route53_zone.assessment_private.name}"
+        hostname = "debiandesktop${count.index}"
     })
     content_type = "text/cloud-config"
     filename     = "set-hostname.yml"
@@ -60,52 +60,6 @@ data "cloudinit_config" "assessorportal_cloud_init_tasks" {
     })
     content_type = "text/x-shellscript"
     filename     = "mount-efs-share.sh"
-  }
-
-  # Create the JSON file used to configure Docker daemon.  This allows us
-  # to tell Docker to store volume data on our persistent
-  # EBS Docker data volume (created below).
-  part {
-    content = templatefile(
-      "${path.module}/cloud-init/write-docker-daemon-json.tpl.yml", {
-        docker_data_root_dir = local.docker_volume_mount_point
-    })
-    content_type = "text/cloud-config"
-    filename     = "write-docker-daemon-json.yml"
     merge_type   = "list(append)+dict(recurse_array)+str()"
-  }
-
-  # Prepare and mount EBS volume to hold Docker data-root data.
-  # Note that this script and the next one must take place in a certain order,
-  # so we prepend numbers to the script names to force that to that happen.
-  #
-  # Here is where the user scripts are called by cloud-init:
-  # https://github.com/canonical/cloud-init/blob/master/cloudinit/config/cc_scripts_user.py#L45
-  #
-  # And here is where you can see how cloud-init sorts the scripts:
-  # https://github.com/canonical/cloud-init/blob/master/cloudinit/subp.py#L373
-  part {
-    content = templatefile(
-      "${path.module}/cloud-init/ebs-disk-setup.tpl.sh", {
-        device_name   = local.docker_ebs_device_name
-        fs_type       = "ext4"
-        label         = "docker_data"
-        mount_options = "defaults"
-        mount_point   = local.docker_volume_mount_point
-        num_disks     = 2
-    })
-    content_type = "text/x-shellscript"
-    filename     = "01-ebs-disk-setup.sh"
-  }
-
-  # Copy Docker data from default directory to new data-root directory.
-  part {
-    content = templatefile(
-      "${path.module}/cloud-init/copy-docker-data-to-new-root-dir.tpl.sh", {
-        mount_point       = local.docker_volume_mount_point
-        new_data_root_dir = local.docker_volume_mount_point
-    })
-    content_type = "text/x-shellscript"
-    filename     = "02-copy-docker-data-to-new-root-dir.sh"
   }
 }

--- a/debiandesktop_ec2.tf
+++ b/debiandesktop_ec2.tf
@@ -55,9 +55,7 @@ resource "aws_instance" "debiandesktop" {
     volume_size = 128
     volume_type = "gp3"
   }
-  # We can use the same cloud-init code as the Kali instances, since
-  # all it does is set up /etc/fstab to mount the EFS file share.
-  user_data_base64 = data.cloudinit_config.kali_cloud_init_tasks.rendered
+  user_data_base64 = data.cloudinit_config.debiandesktop_cloud_init_tasks[count.index].rendered
   vpc_security_group_ids = [
     aws_security_group.cloudwatch_agent_endpoint_client.id,
     aws_security_group.debiandesktop.id,

--- a/gophish_cloud_init.tf
+++ b/gophish_cloud_init.tf
@@ -18,6 +18,25 @@ data "cloudinit_config" "gophish_cloud_init_tasks" {
   # filenames will also be used as a filename in the scripts
   # directory.
 
+  # Set the local hostname
+  #
+  # We need to go ahead and set the local hostname to the correct
+  # value that will eventually be obtained from DHCP, since we make
+  # liberal use of the "{local_hostname}" placeholder in our AWS
+  # CloudWatch Agent configuration.
+  part {
+    content = templatefile(
+      "${path.module}/cloud-init/set-hostname.tpl.yml", {
+        # Note that the hostname here is identical to what is set in
+        # the corresponding DNS A record.
+        fqdn     = "gophish${count.index}.${aws_route53_zone.assessment_private.name}"
+        hostname = "gophish${count.index}"
+    })
+    content_type = "text/cloud-config"
+    filename     = "set-hostname.yml"
+    merge_type   = "list(append)+dict(recurse_array)+str()"
+  }
+
   # Create an fstab entry for the EFS share
   part {
     content = templatefile(

--- a/guacamole_cloud_init.tf
+++ b/guacamole_cloud_init.tf
@@ -17,6 +17,25 @@ data "cloudinit_config" "guacamole_cloud_init_tasks" {
   # mime-parts of the user-data.  It does not affect the final name for the
   # templates.
 
+  # Set the local hostname.
+  #
+  # We need to go ahead and set the local hostname to the correct
+  # value that will eventually be obtained from DHCP, since we make
+  # liberal use of the "{local_hostname}" placeholder in our AWS
+  # CloudWatch Agent configuration.
+  part {
+    content = templatefile(
+      "${path.module}/cloud-init/set-hostname.tpl.yml", {
+        # Note that the hostname here is identical to what is set in
+        # the corresponding DNS A record.
+        fqdn     = "guac.${aws_route53_zone.assessment_private.name}"
+        hostname = "guac"
+    })
+    content_type = "text/cloud-config"
+    filename     = "set-hostname.yml"
+    merge_type   = "list(append)+dict(recurse_array)+str()"
+  }
+
   # Set environment variables required to enroll in the FreeIPA
   # domain.
   part {

--- a/kali_cloud_init.tf
+++ b/kali_cloud_init.tf
@@ -1,6 +1,8 @@
 # cloud-init commands for configuring Kali instances
 
 data "cloudinit_config" "kali_cloud_init_tasks" {
+  count = lookup(var.operations_instance_counts, "kali", 0)
+
   gzip          = true
   base64_encode = true
 
@@ -9,6 +11,25 @@ data "cloudinit_config" "kali_cloud_init_tasks" {
   # final name for the templates. For any x-shellscript parts, the
   # filenames will also be used as a filename in the scripts
   # directory.
+
+  # Set the local hostname.
+  #
+  # We need to go ahead and set the local hostname to the correct
+  # value that will eventually be obtained from DHCP, since we make
+  # liberal use of the "{local_hostname}" placeholder in our AWS
+  # CloudWatch Agent configuration.
+  part {
+    content = templatefile(
+      "${path.module}/cloud-init/set-hostname.tpl.yml", {
+        # Note that the hostname here is identical to what is set in
+        # the corresponding DNS A record.
+        fqdn     = "kali${count.index}.${aws_route53_zone.assessment_private.name}"
+        hostname = "kali${count.index}"
+    })
+    content_type = "text/cloud-config"
+    filename     = "set-hostname.yml"
+    merge_type   = "list(append)+dict(recurse_array)+str()"
+  }
 
   # Create an fstab entry for the EFS share
   part {

--- a/kali_ec2.tf
+++ b/kali_ec2.tf
@@ -55,7 +55,7 @@ resource "aws_instance" "kali" {
     volume_size = 128
     volume_type = "gp3"
   }
-  user_data_base64 = data.cloudinit_config.kali_cloud_init_tasks.rendered
+  user_data_base64 = data.cloudinit_config.kali_cloud_init_tasks[count.index].rendered
   vpc_security_group_ids = [
     aws_security_group.cloudwatch_agent_endpoint_client.id,
     aws_security_group.efs_client.id,

--- a/nessus_cloud_init.tf
+++ b/nessus_cloud_init.tf
@@ -11,6 +11,25 @@ data "cloudinit_config" "nessus_cloud_init_tasks" {
   # templates. For x-shellscript parts, it will also be used as a filename
   # in the scripts directory.
 
+  # Set the local hostname.
+  #
+  # We need to go ahead and set the local hostname to the correct
+  # value that will eventually be obtained from DHCP, since we make
+  # liberal use of the "{local_hostname}" placeholder in our AWS
+  # CloudWatch Agent configuration.
+  part {
+    content = templatefile(
+      "${path.module}/cloud-init/set-hostname.tpl.yml", {
+        # Note that the hostname here is identical to what is set in
+        # the corresponding DNS A record.
+        fqdn     = "nessus${count.index}.${aws_route53_zone.assessment_private.name}"
+        hostname = "nessus${count.index}"
+    })
+    content_type = "text/cloud-config"
+    filename     = "set-hostname.yml"
+    merge_type   = "list(append)+dict(recurse_array)+str()"
+  }
+
   part {
     filename     = "nessus-setup.sh"
     content_type = "text/x-shellscript"

--- a/pentestportal_cloud_init.tf
+++ b/pentestportal_cloud_init.tf
@@ -1,7 +1,7 @@
-# cloud-init commands for configuring Assessor Portal instances
+# cloud-init commands for configuring Pentest Portal instances
 
-data "cloudinit_config" "assessorportal_cloud_init_tasks" {
-  count = lookup(var.operations_instance_counts, "assessorportal", 0)
+data "cloudinit_config" "pentestportal_cloud_init_tasks" {
+  count = lookup(var.operations_instance_counts, "pentestportal", 0)
 
   gzip          = true
   base64_encode = true
@@ -23,8 +23,8 @@ data "cloudinit_config" "assessorportal_cloud_init_tasks" {
       "${path.module}/cloud-init/set-hostname.tpl.yml", {
         # Note that the hostname here is identical to what is set in
         # the corresponding DNS A record.
-        fqdn     = "assessorportal${count.index}.${aws_route53_zone.assessment_private.name}"
-        hostname = "assessorportal${count.index}"
+        fqdn     = "pentestportal${count.index + 1}.${aws_route53_zone.assessment_private.name}"
+        hostname = "pentestportal${count.index + 1}"
     })
     content_type = "text/cloud-config"
     filename     = "set-hostname.yml"
@@ -60,52 +60,6 @@ data "cloudinit_config" "assessorportal_cloud_init_tasks" {
     })
     content_type = "text/x-shellscript"
     filename     = "mount-efs-share.sh"
-  }
-
-  # Create the JSON file used to configure Docker daemon.  This allows us
-  # to tell Docker to store volume data on our persistent
-  # EBS Docker data volume (created below).
-  part {
-    content = templatefile(
-      "${path.module}/cloud-init/write-docker-daemon-json.tpl.yml", {
-        docker_data_root_dir = local.docker_volume_mount_point
-    })
-    content_type = "text/cloud-config"
-    filename     = "write-docker-daemon-json.yml"
     merge_type   = "list(append)+dict(recurse_array)+str()"
-  }
-
-  # Prepare and mount EBS volume to hold Docker data-root data.
-  # Note that this script and the next one must take place in a certain order,
-  # so we prepend numbers to the script names to force that to that happen.
-  #
-  # Here is where the user scripts are called by cloud-init:
-  # https://github.com/canonical/cloud-init/blob/master/cloudinit/config/cc_scripts_user.py#L45
-  #
-  # And here is where you can see how cloud-init sorts the scripts:
-  # https://github.com/canonical/cloud-init/blob/master/cloudinit/subp.py#L373
-  part {
-    content = templatefile(
-      "${path.module}/cloud-init/ebs-disk-setup.tpl.sh", {
-        device_name   = local.docker_ebs_device_name
-        fs_type       = "ext4"
-        label         = "docker_data"
-        mount_options = "defaults"
-        mount_point   = local.docker_volume_mount_point
-        num_disks     = 2
-    })
-    content_type = "text/x-shellscript"
-    filename     = "01-ebs-disk-setup.sh"
-  }
-
-  # Copy Docker data from default directory to new data-root directory.
-  part {
-    content = templatefile(
-      "${path.module}/cloud-init/copy-docker-data-to-new-root-dir.tpl.sh", {
-        mount_point       = local.docker_volume_mount_point
-        new_data_root_dir = local.docker_volume_mount_point
-    })
-    content_type = "text/x-shellscript"
-    filename     = "02-copy-docker-data-to-new-root-dir.sh"
   }
 }

--- a/pentestportal_ec2.tf
+++ b/pentestportal_ec2.tf
@@ -55,9 +55,7 @@ resource "aws_instance" "pentestportal" {
     volume_size = 128
     volume_type = "gp3"
   }
-  # We can use the same cloud-init code as the Kali instances, since
-  # all it does is set up /etc/fstab to mount the EFS file share.
-  user_data_base64 = data.cloudinit_config.kali_cloud_init_tasks.rendered
+  user_data_base64 = data.cloudinit_config.pentestportal_cloud_init_tasks[count.index].rendered
   vpc_security_group_ids = [
     aws_security_group.cloudwatch_agent_endpoint_client.id,
     aws_security_group.efs_client.id,

--- a/samba_cloud_init.tf
+++ b/samba_cloud_init.tf
@@ -1,6 +1,8 @@
 # cloud-init commands for configuring SMB server instances
 
 data "cloudinit_config" "samba_cloud_init_tasks" {
+  count = lookup(var.operations_instance_counts, "samba", 0)
+
   gzip          = true
   base64_encode = true
 
@@ -9,6 +11,25 @@ data "cloudinit_config" "samba_cloud_init_tasks" {
   # final name for the templates. For any x-shellscript parts, the
   # filenames will also be used as a filename in the scripts
   # directory.
+
+  # Set the local hostname.
+  #
+  # We need to go ahead and set the local hostname to the correct
+  # value that will eventually be obtained from DHCP, since we make
+  # liberal use of the "{local_hostname}" placeholder in our AWS
+  # CloudWatch Agent configuration.
+  part {
+    content = templatefile(
+      "${path.module}/cloud-init/set-hostname.tpl.yml", {
+        # Note that the hostname here is identical to what is set in
+        # the corresponding DNS A record.
+        fqdn     = "samba${count.index}.${aws_route53_zone.assessment_private.name}"
+        hostname = "samba${count.index}"
+    })
+    content_type = "text/cloud-config"
+    filename     = "set-hostname.yml"
+    merge_type   = "list(append)+dict(recurse_array)+str()"
+  }
 
   # Create an fstab entry for the EFS share
   part {

--- a/samba_ec2.tf
+++ b/samba_ec2.tf
@@ -62,7 +62,7 @@ resource "aws_instance" "samba" {
     volume_size = 16
     volume_type = "gp3"
   }
-  user_data_base64 = data.cloudinit_config.samba_cloud_init_tasks.rendered
+  user_data_base64 = data.cloudinit_config.samba_cloud_init_tasks[count.index].rendered
   vpc_security_group_ids = [
     aws_security_group.cloudwatch_agent_endpoint_client.id,
     aws_security_group.efs_client.id,

--- a/teamserver_cloud_init.tf
+++ b/teamserver_cloud_init.tf
@@ -19,6 +19,25 @@ data "cloudinit_config" "teamserver_cloud_init_tasks" {
   # filenames will also be used as a filename in the scripts
   # directory.
 
+  # Set the local hostname.
+  #
+  # We need to go ahead and set the local hostname to the correct
+  # value that will eventually be obtained from DHCP, since we make
+  # liberal use of the "{local_hostname}" placeholder in our AWS
+  # CloudWatch Agent configuration.
+  part {
+    content = templatefile(
+      "${path.module}/cloud-init/set-hostname.tpl.yml", {
+        # Note that the hostname here is identical to what is set in
+        # the corresponding DNS A record.
+        fqdn     = "teamserver${count.index}.${aws_route53_zone.assessment_private.name}"
+        hostname = "teamserver${count.index}"
+    })
+    content_type = "text/cloud-config"
+    filename     = "set-hostname.yml"
+    merge_type   = "list(append)+dict(recurse_array)+str()"
+  }
+
   # Create an fstab entry for the EFS share
   part {
     content = templatefile(

--- a/terraformer_cloud_init.tf
+++ b/terraformer_cloud_init.tf
@@ -1,6 +1,8 @@
 # cloud-init commands for configuring Terraformer instances
 
 data "cloudinit_config" "terraformer_cloud_init_tasks" {
+  count = lookup(var.operations_instance_counts, "terraformer", 0)
+
   gzip          = true
   base64_encode = true
 
@@ -9,6 +11,25 @@ data "cloudinit_config" "terraformer_cloud_init_tasks" {
   # final name for the templates. For any x-shellscript parts, the
   # filenames will also be used as a filename in the scripts
   # directory.
+
+  # Set the local hostname.
+  #
+  # We need to go ahead and set the local hostname to the correct
+  # value that will eventually be obtained from DHCP, since we make
+  # liberal use of the "{local_hostname}" placeholder in our AWS
+  # CloudWatch Agent configuration.
+  part {
+    content = templatefile(
+      "${path.module}/cloud-init/set-hostname.tpl.yml", {
+        # Note that the hostname here is identical to what is set in
+        # the corresponding DNS A record.
+        fqdn     = "terraformer${count.index}.${aws_route53_zone.assessment_private.name}"
+        hostname = "terraformer${count.index}"
+    })
+    content_type = "text/cloud-config"
+    filename     = "set-hostname.yml"
+    merge_type   = "list(append)+dict(recurse_array)+str()"
+  }
 
   # Create an fstab entry for the EFS share
   part {

--- a/terraformer_ec2.tf
+++ b/terraformer_ec2.tf
@@ -62,7 +62,7 @@ resource "aws_instance" "terraformer" {
     volume_size = 20
     volume_type = "gp3"
   }
-  user_data_base64 = data.cloudinit_config.terraformer_cloud_init_tasks.rendered
+  user_data_base64 = data.cloudinit_config.terraformer_cloud_init_tasks[count.index].rendered
   vpc_security_group_ids = [
     aws_security_group.cloudwatch_agent_endpoint_client.id,
     aws_security_group.dynamodb_endpoint_client.id,


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds `cloud-init` code to preemptively set the hostname on all instance types.

## 💭 Motivation and context ##

We need to go ahead and set the local hostname to the correct value that will eventually be obtained from DHCP, since we make liberal use of the `{local_hostname}` placeholder in our AWS CloudWatch Agent configuration.

## 🧪 Testing ##

I verified in env6-staging that these changes appear to cause the correct hostname to be used by the CloudWatch Agent.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.