### PR TITLE
Add EFS tag/untag permissions to ProvisionAssessment

### DIFF
--- a/provisionassessment_policy.tf
+++ b/provisionassessment_policy.tf
@@ -111,6 +111,8 @@ data "aws_iam_policy_document" "provisionassessment_policy_doc" {
       "elasticfilesystem:DescribeLifecycleConfiguration",
       "elasticfilesystem:DescribeMountTargets",
       "elasticfilesystem:DescribeMountTargetSecurityGroups",
+      "elasticfilesystem:TagResource",
+      "elasticfilesystem:UntagResource",
     ]
 
     resources = [


### PR DESCRIPTION


# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds EFS tagging and untagging permissions to the `ProvisionAssessment` policy.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

When an existing environment was attempting to be updated, we discovered that we need these permissions.  It's unclear if this was always an issue or if something changed recently to cause it.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I confirmed that adding these new permissions to the policy in an existing environment enabled Terraform to successfully tag the existing EFS resources (which it previously was unable to do).

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

