### PR TITLE
Ensure that EBS volumes are destroyed correctly

### DIFF
--- a/gophish_ec2.tf
+++ b/gophish_ec2.tf
@@ -26,8 +26,8 @@ data "aws_ami" "gophish" {
 # The Gophish EC2 instances
 resource "aws_instance" "gophish" {
   count = lookup(var.operations_instance_counts, "gophish", 0)
-  # These instances require the EBS Docker volume and EFS mount target to be
-  # present so that both volumes can be mounted at boot time.
+  # These instances require the EBS Docker volume and EFS mount target
+  # to be present so that both volumes can be mounted at boot time.
   depends_on = [
     aws_ebs_volume.gophish_docker,
     aws_efs_mount_target.target,
@@ -123,9 +123,10 @@ resource "aws_volume_attachment" "gophish_docker" {
   count    = lookup(var.operations_instance_counts, "gophish", 0)
   provider = aws.provisionassessment
 
-  device_name = local.docker_ebs_device_name
-  instance_id = aws_instance.gophish[count.index].id
-  volume_id   = aws_ebs_volume.gophish_docker[count.index].id
+  device_name                    = local.docker_ebs_device_name
+  instance_id                    = aws_instance.gophish[count.index].id
+  stop_instance_before_detaching = true
+  volume_id                      = aws_ebs_volume.gophish_docker[count.index].id
 }
 
 # CloudWatch alarms for the Gophish instances


### PR DESCRIPTION
## 🗣 Description ##

This pull request ensures that EBS volumes are destroyed correctly; namely, by first stopping the instance to which they are attached.  It also adds any EBS volumes to the corresponding instance's `depends_on` attribute.

## 💭 Motivation and context ##

These changes are analogous to those made in cisagov/cyhy_amis#427.

## 🧪 Testing ##

I have created and destroyed env6-staging a few times with these changes and verified that nothing unexpected happens.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.