### PR TITLE
Add missing permissions for the SSM session log group

### DIFF
--- a/provisionassessment_policy.tf
+++ b/provisionassessment_policy.tf
@@ -182,6 +182,7 @@ data "aws_iam_policy_document" "provisionassessment_policy_doc" {
 
     resources = [
       "arn:aws:logs:${var.aws_region}:${local.assessment_account_id}:log-group:vpc-flow-logs-*",
+      "${module.session_manager.ssm_session_log_group.arn}:*",
     ]
   }
 }


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds some missing permissions related to the SSM session log group.

## 💭 Motivation and context ##

@dav3r and I helped @mkreckel debug some issues he saw when destroying COOL assessment environments, and I realized that these permissions were necessary but missing.

## 🧪 Testing ##

I was able to cleanly destroy a COOL assessment environment with these changes.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.