### PR TITLE
Fix bug in validation equality check

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -97,7 +97,14 @@ variable "email_sending_domains" {
   default     = ["example.com"]
 
   validation {
-    condition     = var.email_sending_domains == [for d in var.email_sending_domains : lower(d)]
+    # Note that [] actually creates a tuple, which will always compare
+    # to false against a list because a list and a tuple are different
+    # types.  Therefore the tolist() on the right-hand side is
+    # necessary.
+    #
+    # See here for a brief warning related to this very situation:
+    # https://www.terraform.io/language/expressions/operators#equality-operators
+    condition     = var.email_sending_domains == tolist([for d in var.email_sending_domains : lower(d)])
     error_message = "All of the values in email_sending_domains must be lowercase."
   }
 }


### PR DESCRIPTION
## 🗣 Description ##

This pull request fixes a bug in an equality check in a Terraform variable's validation code.

## 💭 Motivation and context ##

This is necessary because the `[]` operator in Terraform actually creates a tuple, and a tuple will always compare to `false` against a list because they are different types.  [The Terraform documentation](https://www.terraform.io/language/expressions/operators#equality-operators) warns against this very situation.

I noticed this flaw yesterday when helping @mkreckel with some issues he was having creating COOL assessment environments.  At that time I temporarily commented out the validation code as a workaround.

## 🧪 Testing ##

I used the `terraform console` command to verify that this change indeed fixes the issue:
```terraform
$ terraform console -var-file=envXX-production.tfvars
<snip>

> var.email_sending_domains
tolist([
  "abc.org",
  "def.com",
])
> var.email_sending_domains == [for d in var.email_sending_domains : lower(d)]
false
> var.email_sending_domains == tolist([for d in var.email_sending_domains : lower(d)])
true

<snip>
```

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.