### PR TITLE
Fix reference to docker-compose in comment

### DIFF
--- a/cloud-init/postfix-setup.tpl.yml
+++ b/cloud-init/postfix-setup.tpl.yml
@@ -1,6 +1,6 @@
 ---
 runcmd:
-  # Modify postfix's PRIMARY_DOMAIN in pca-gophish-composition Docker
+  # Modify postfix's PRIMARY_DOMAIN in the pca-gophish-composition Docker
   # composition file to the email-sending domain for this assessment
   - [sed, -i,
      "s|^\\([- \\w]*\\)PRIMARY_DOMAIN=[^\\w]*$|\

--- a/cloud-init/postfix-setup.tpl.yml
+++ b/cloud-init/postfix-setup.tpl.yml
@@ -1,7 +1,7 @@
 ---
 runcmd:
-  # Modify postfix's PRIMARY_DOMAIN in pca-gophish-composition docker-compose
-  # file to the email-sending domain for this assessment
+  # Modify postfix's PRIMARY_DOMAIN in pca-gophish-composition Docker
+  # composition file to the email-sending domain for this assessment
   - [sed, -i,
      "s|^\\([- \\w]*\\)PRIMARY_DOMAIN=[^\\w]*$|\
      \\1PRIMARY_DOMAIN=${email_sending_domain}|g",


### PR DESCRIPTION
## 🗣 Description ##

This pull request updates some comments to use the `docker compose` syntax instead of the `docker-compose` syntax.

## 💭 Motivation and context ##

The `docker compose` syntax is the preferred (and only correct) syntax after the changes in cisagov/ansible-role-docker#60.

## 🧪 Testing ##

Automated testing passes.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.