### PR TITLE
Modify sleep argument to remove units

### DIFF
--- a/transitgateway.tf
+++ b/transitgateway.tf
@@ -43,7 +43,7 @@ resource "null_resource" "break_association_with_default_route_table" {
     # This command asks AWS to disassociate the default route table
     # from our transit gateway attachment, then loops until the
     # disassociation is complete.
-    command = "aws --profile cool-sharedservices-provisionaccount --region ${var.aws_region} ec2 disassociate-transit-gateway-route-table --transit-gateway-route-table-id ${local.transit_gateway_default_route_table_id} --transit-gateway-attachment-id ${aws_ec2_transit_gateway_vpc_attachment.assessment.id} && while aws --profile cool-sharedservices-provisionaccount --region ${var.aws_region} ec2 get-transit-gateway-route-table-associations --transit-gateway-route-table-id ${local.transit_gateway_default_route_table_id} | grep --quiet ${aws_vpc.assessment.id}; do sleep 5s; done"
+    command = "aws --profile cool-sharedservices-provisionaccount --region ${var.aws_region} ec2 disassociate-transit-gateway-route-table --transit-gateway-route-table-id ${local.transit_gateway_default_route_table_id} --transit-gateway-attachment-id ${aws_ec2_transit_gateway_vpc_attachment.assessment.id} && while aws --profile cool-sharedservices-provisionaccount --region ${var.aws_region} ec2 get-transit-gateway-route-table-associations --transit-gateway-route-table-id ${local.transit_gateway_default_route_table_id} | grep --quiet ${aws_vpc.assessment.id}; do sleep 5; done"
   }
 
   triggers = {


### PR DESCRIPTION


# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR removes the units (seconds) from the sleep command.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

On macOS Monterey, the `sleep` CLI command will not accept units, only integers, so `sleep 5s` will not work (as it has on past versions of `sleep` included with macOS).  As far as I can tell, this change appears to be compatible with other Linux distributions.

Resolves #195.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I verified that this syntax works with the version of `sleep` that comes with macOS Catalina.  @tauhid-smith-ctr verified that this syntax works with the version of `sleep` that comes with macOS Monterey.  @jsf9k verified that this syntax works with the version of `sleep` that he has on his Arch system.  I also confirmed that the [man page for `sleep`](https://linux.die.net/man/3/sleep) shows that this command expects a number of seconds.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
