### PR TITLE
Inject a dependency of the session manager module on the corresponding policy

### DIFF
--- a/provisionssmsessionmanager_policy.tf
+++ b/provisionssmsessionmanager_policy.tf
@@ -41,7 +41,7 @@ data "aws_iam_policy_document" "provisionssmsessionmanager_policy_doc" {
     ]
 
     resources = [
-      "arn:aws:logs:${var.aws_region}:${local.assessment_account_id}:log-group:${module.session_manager.ssm_session_log_group.name}:*",
+      "arn:aws:logs:${var.aws_region}:${local.assessment_account_id}:log-group:${var.session_cloudwatch_log_group_name}:*",
     ]
   }
 }

--- a/session_manager.tf
+++ b/session_manager.tf
@@ -3,11 +3,15 @@
 # ------------------------------------------------------------------------------
 
 module "session_manager" {
+  depends_on = [
+    aws_iam_role_policy_attachment.provisionssmsessionmanager_policy_attachment
+  ]
   providers = {
     aws = aws.provisionassessment
   }
   source = "github.com/cisagov/session-manager-tf-module"
 
+  cloudwatch_log_group_name = var.session_cloudwatch_log_group_name
   other_accounts = [
     local.users_account_id,
   ]

--- a/variables.tf
+++ b/variables.tf
@@ -220,8 +220,8 @@ variable "read_terraform_state_role_name" {
 }
 
 # This variable is copied over from cisagov/session-manager-tf-module
-# so that it its value can be specified outside of that module.  This
-# allows is to impose a dependency of the module on the policy that
+# so that its value can be specified outside of that module.  This
+# allows us to impose a dependency of the module on the policy that
 # allows for the creation of its resources; otherwise, this dependency
 # will be cyclical.
 variable "session_cloudwatch_log_group_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -219,6 +219,17 @@ variable "read_terraform_state_role_name" {
   default     = "ReadCoolAssessmentTerraformTerraformState-%s"
 }
 
+# This variable is copied over from cisagov/session-manager-tf-module
+# so that it its value can be specified outside of that module.  This
+# allows is to impose a dependency of the module on the policy that
+# allows for the creation of its resources; otherwise, this dependency
+# will be cyclical.
+variable "session_cloudwatch_log_group_name" {
+  default     = "/ssm/session-logs"
+  description = "The name of the log group into which session logs are to be uploaded."
+  type        = string
+}
+
 variable "ssm_key_nessus_admin_password" {
   type        = string
   description = "The AWS SSM Parameter Store parameter that contains the password of the Nessus admin user (e.g. \"/nessus/assessment/admin_password\")."


### PR DESCRIPTION
## 🗣 Description ##

This pull request copies a variable together with its default value over from the [cisagov/session-manager-tf-module](https://github.com/cisagov/session-manager-tf-module) so that it its value can be specified without referring to the module.  This allows us to impose a dependency of the module on the policy attachment that allows for the creation of its resources; otherwise, this dependency will be cyclical.

## 💭 Motivation and context ##

This change gets rid of the dangling CloudWatch log group and SSM document resources that can result when the policy that allows for the creation and destruction of these resources is deleted before the resources are destroyed.

## 🧪 Testing ##

I created and destroyed `env6-staging` several times without issue using these changes.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.