### PR TITLE
Add sort() calls to validation code

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -104,7 +104,10 @@ variable "email_sending_domains" {
     #
     # See here for a brief warning related to this very situation:
     # https://www.terraform.io/language/expressions/operators#equality-operators
-    condition     = var.email_sending_domains == tolist([for d in var.email_sending_domains : lower(d)])
+    #
+    # The sort() calls are necessary, since tolist(["a", "b", "c"]) !=
+    # tolist(["c", "b", "a"]) in Terraform.
+    condition     = sort(var.email_sending_domains) == sort(tolist([for d in var.email_sending_domains : lower(d)]))
     error_message = "All of the values in email_sending_domains must be lowercase."
   }
 }


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds some `sort()` calls to the validation code for the `email_sending_domains` input variable.

## 💭 Motivation and context ##

This is necessary since `tolist(["a", "b", "c"]) != tolist(["c", "b","a"])` in Terraform.

## 🧪 Testing ##

I verified via `terraform console` that
```hcl
sort(tolist(["a", "b", "c"])) == sort(tolist(["c", "b","a"]))
```

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All new and existing tests pass.