### PR TITLE
Bump up size of pentestportal instances

### DIFF
--- a/pentestportal_ec2.tf
+++ b/pentestportal_ec2.tf
@@ -38,7 +38,7 @@ resource "aws_instance" "pentestportal" {
   ami                         = data.aws_ami.docker.id
   associate_public_ip_address = true
   iam_instance_profile        = aws_iam_instance_profile.pentestportal.name
-  instance_type               = "t3.small"
+  instance_type               = "t3.medium"
   subnet_id                   = aws_subnet.operations.id
   # AWS Instance Meta-Data Service (IMDS) options
   metadata_options {


### PR DESCRIPTION

A similar change was made in #106 for our Debian Desktop instances.

# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request bumps up the size of the PenTestPortal instance from `t3.small` to `t3.medium`.


<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

In the past, we have seen fairly regular occurrences of these PTP instances locking up, which is likely due to lack of available memory.

These PTPs were running as `t3.small` instances, which have a mere 2GB of RAM.  That's a bit thin on memory for running Linux with a desktop environment and a modern web browser, so I bumped the instance type up to a `t3.medium`.   The `t3.medium` instances have 4GB of RAM, which should improve our situation.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

The efficacy of this change will be determined by whether or not we see a decrease in the number of trouble tickets to restart locked-up PTP instances in Production.

CC: @mkreckel @tauhid-smith-ctr @m1j09830

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.