### PR TITLE
Increase root disk for Guacamole instance

### DIFF
--- a/guacamole_ec2.tf
+++ b/guacamole_ec2.tf
@@ -68,7 +68,7 @@ resource "aws_instance" "guacamole" {
     http_tokens = "required"
   }
   root_block_device {
-    volume_size = 8
+    volume_size = 32
     volume_type = "gp3"
   }
   user_data_base64 = data.cloudinit_config.guacamole_cloud_init_tasks.rendered


### PR DESCRIPTION
## 🗣 Description ##

This pull request increases the root disk size for Guacamole instances from 8GB to 32GB.

## 💭 Motivation and context ##

Resolves #202.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.