### PR TITLE
Add variables for assessment ID and type

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,6 +411,8 @@ the COOL environment.
 | [aws_vpc_endpoint_subnet_association.ssmmessages](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint_subnet_association) | resource |
 | [aws_vpc_endpoint_subnet_association.sts](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint_subnet_association) | resource |
 | [null_resource.break_association_with_default_route_table](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [null_resource.validate_assessment_id](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [null_resource.validate_assessment_type](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [aws_ami.assessorportal](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_ami.debiandesktop](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_ami.docker](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
@@ -471,6 +473,8 @@ the COOL environment.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | assessment\_account\_name | The name of the AWS account for this assessment (e.g. "env0"). | `string` | n/a | yes |
+| assessment\_id | The identifier for this assessment (e.g. "ASMT1234"). | `string` | `""` | no |
+| assessment\_type | The type of this assessment (e.g. "PenTest"). | `string` | `""` | no |
 | assessmentfindingsbucketwrite\_sharedservices\_policy\_description | The description to associate with the IAM policy that allows assumption of the role in the Shared Services account that is allowed to write to the assessment findings bucket. | `string` | `"Allows assumption of the role in the Shared Services account that is allowed to write to the assessment findings bucket."` | no |
 | assessmentfindingsbucketwrite\_sharedservices\_policy\_name | The name to assign the IAM policy that allows assumption of the role in the Shared Services account that is allowed to write to the assessment findings bucket. | `string` | `"SharedServices-AssumeAssessmentFindingsBucketWrite"` | no |
 | assessor\_account\_role\_arn | The ARN of an IAM role that can be assumed to create, delete, and modify AWS resources in a separate assessor-owned AWS account. | `string` | `"arn:aws:iam::123456789012:role/Allow_It"` | no |
@@ -506,6 +510,8 @@ the COOL environment.
 | tags | Tags to apply to all AWS resources created | `map(string)` | `{}` | no |
 | terraformer\_role\_description | The description to associate with the IAM role (and policy) that allows Terraformer instances to create appropriate AWS resources in this account. | `string` | `"Allows Terraformer instances to create appropriate AWS resources in this account."` | no |
 | terraformer\_role\_name | The name to assign the IAM role (and policy) that allows Terraformer instances to create appropriate AWS resources in this account. | `string` | `"Terraformer"` | no |
+| valid\_assessment\_id\_regex | A regular expression that specifies valid assessment identifiers (e.g. "^ASMT[[:digit:]]{4}$"). | `string` | `""` | no |
+| valid\_assessment\_types | A list of valid assessment types (e.g. ["PenTest", "Phishing", "RedTeam"]). | `list(string)` | ```[ "" ]``` | no |
 | vpc\_cidr\_block | The CIDR block to use this assessment's VPC (e.g. "10.224.0.0/21"). | `string` | n/a | yes |
 | windows\_with\_docker | A boolean to control the instance type used when creating Windows instances to allow Docker Desktop support. Windows instances require the `metal` instance type to run Docker Desktop because of nested virtualization, but if Docker Desktop is not needed then other instance types are fine. | `bool` | `false` | no |
 

--- a/README.md
+++ b/README.md
@@ -511,7 +511,7 @@ the COOL environment.
 | terraformer\_role\_description | The description to associate with the IAM role (and policy) that allows Terraformer instances to create appropriate AWS resources in this account. | `string` | `"Allows Terraformer instances to create appropriate AWS resources in this account."` | no |
 | terraformer\_role\_name | The name to assign the IAM role (and policy) that allows Terraformer instances to create appropriate AWS resources in this account. | `string` | `"Terraformer"` | no |
 | valid\_assessment\_id\_regex | A regular expression that specifies valid assessment identifiers (e.g. "^ASMT[[:digit:]]{4}$"). | `string` | `""` | no |
-| valid\_assessment\_types | A list of valid assessment types (e.g. ["PenTest", "Phishing", "RedTeam"]). | `list(string)` | ```[ "" ]``` | no |
+| valid\_assessment\_types | A list of valid assessment types (e.g. ["PenTest", "Phishing", "RedTeam"]).  If this list is empty (i.e. []), then any value used for assessment\_type will trigger a validation error. | `list(string)` | ```[ "" ]``` | no |
 | vpc\_cidr\_block | The CIDR block to use this assessment's VPC (e.g. "10.224.0.0/21"). | `string` | n/a | yes |
 | windows\_with\_docker | A boolean to control the instance type used when creating Windows instances to allow Docker Desktop support. Windows instances require the `metal` instance type to run Docker Desktop because of nested virtualization, but if Docker Desktop is not needed then other instance types are fine. | `bool` | `false` | no |
 

--- a/assessment_validation.tf
+++ b/assessment_validation.tf
@@ -1,0 +1,28 @@
+# This file contains a semi-hacky way of validating user-provided assessment
+# information.  As of Terraform v1.3.x, there is no built-in way to validate
+# one variable against another, as we need to do here.  Terraform input variable
+# validation expressions can only refer to the variable being validated and no
+# others.  For more, see
+# https://developer.hashicorp.com/terraform/language/expressions/custom-conditions#input-variable-validation
+#
+# To work around this limitation, we use a null_resource with a lifecycle block
+# that contains a precondition.  The precondition is evaluated at plan time, and
+# if it fails, the plan will fail with the error message provided.
+
+resource "null_resource" "validate_assessment_id" {
+  lifecycle {
+    precondition {
+      condition     = length(regexall(var.valid_assessment_id_regex, var.assessment_id)) == 1
+      error_message = "Invalid assessment identifier provided: ${var.assessment_id}.  Valid assessment identifiers must match this regular expression: ${var.valid_assessment_id_regex}"
+    }
+  }
+}
+
+resource "null_resource" "validate_assessment_type" {
+  lifecycle {
+    precondition {
+      condition     = contains(var.valid_assessment_types, var.assessment_type)
+      error_message = "Invalid assessment type provided: ${var.assessment_type}.  Valid types are: ${join(", ", var.valid_assessment_types)}"
+    }
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -314,8 +314,11 @@ variable "valid_assessment_id_regex" {
 
 variable "valid_assessment_types" {
   type        = list(string)
-  description = "A list of valid assessment types (e.g. [\"PenTest\", \"Phishing\", \"RedTeam\"])."
-  default     = [""]
+  description = "A list of valid assessment types (e.g. [\"PenTest\", \"Phishing\", \"RedTeam\"]).  If this list is empty (i.e. []), then any value used for assessment_type will trigger a validation error."
+  # Set the default value to [""] instead of [] to match the default value of
+  # var.assessment_type, which is "".  This is done to avoid a validation error
+  # when the default values of both variables are used.
+  default = [""]
 }
 
 variable "windows_with_docker" {

--- a/variables.tf
+++ b/variables.tf
@@ -48,6 +48,18 @@ variable "assessmentfindingsbucketwrite_sharedservices_policy_name" {
   default     = "SharedServices-AssumeAssessmentFindingsBucketWrite"
 }
 
+variable "assessment_id" {
+  type        = string
+  description = "The identifier for this assessment (e.g. \"ASMT1234\")."
+  default     = ""
+}
+
+variable "assessment_type" {
+  type        = string
+  description = "The type of this assessment (e.g. \"PenTest\")."
+  default     = ""
+}
+
 variable "aws_availability_zone" {
   type        = string
   description = "The AWS availability zone to deploy into (e.g. a, b, c, etc.)"
@@ -292,6 +304,18 @@ variable "terraformer_role_name" {
   type        = string
   description = "The name to assign the IAM role (and policy) that allows Terraformer instances to create appropriate AWS resources in this account."
   default     = "Terraformer"
+}
+
+variable "valid_assessment_id_regex" {
+  type        = string
+  description = "A regular expression that specifies valid assessment identifiers (e.g. \"^ASMT[[:digit:]]{4}$\")."
+  default     = ""
+}
+
+variable "valid_assessment_types" {
+  type        = list(string)
+  description = "A list of valid assessment types (e.g. [\"PenTest\", \"Phishing\", \"RedTeam\"])."
+  default     = [""]
 }
 
 variable "windows_with_docker" {


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds new optional variables for assessment identifier, assessment type, valid assessment identifier regular expression, and valid assessment types.  If provided, the assessment identifier is validated against the valid assessment identifier regular expression and the assessment type is validated against the list of valid assessment types. 

## 💭 Motivation and context ##

Defining assessment types and identifiers is a necessary precursor for the work planned for https://github.com/cisagov/cool-system-internal/issues/3.  A subsequent PR will add a script that can copy assessment results to an S3 bucket using a standard naming scheme based on assessment type and identifier.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I verified the following:
* When none of these (optional) new variables are supplied, no validation errors are thrown during a `terraform plan` or `terraform apply`.
* When an assessment ID is provided, but no valid ID regex is provided, an error like the following is thrown:
```
│ Error: Resource precondition failed
│ 
│   on assessment_validation.tf line 15, in resource "null_resource" "validate_assessment_id":
│   15:       condition     = length(regexall(var.valid_assessment_id_regex, var.assessment_id)) == 1
│     ├────────────────
│     │ var.assessment_id is "ASMT1234"
│     │ var.valid_assessment_id_regex is ""
│ 
│ Invalid assessment identifier provided: ASMT1234.  Valid assessment identifiers must match this regular expression:
```
* When an assessment ID is provided that does not match the provided regex for valid IDs, an error like the following is thrown:
```
│ Error: Resource precondition failed
│ 
│   on assessment_validation.tf line 15, in resource "null_resource" "validate_assessment_id":
│   15:       condition     = length(regexall(var.valid_assessment_id_regex, var.assessment_id)) == 1
│     ├────────────────
│     │ var.assessment_id is "ASMT-X23"
│     │ var.valid_assessment_id_regex is "^ASMT[[:digit:]]{4}$"
│ 
│ Invalid assessment identifier provided: ASMT-X23.  Valid assessment identifiers must match this regular expression: ^ASMT[[:digit:]]{4}$
```
* When an assessment ID is provided that matches the provided regex for valid IDs, no validation errors are thrown during a `terraform plan` or `terraform apply`.
* When an assessment type is provided, but no list of valid assessment types is provided, an error like the following is thrown:
```
│ Error: Resource precondition failed
│ 
│   on assessment_validation.tf line 24, in resource "null_resource" "validate_assessment_type":
│   24:       condition     = contains(var.valid_assessment_types, var.assessment_type)
│     ├────────────────
│     │ var.assessment_type is "PenTest"
│     │ var.valid_assessment_types is list of string with 1 element
│ 
│ Invalid assessment type provided: PenTest.  Valid types are: PenTest, Phishing, RedTeam
```
* When an assessment type is provided that is not in the provided list of valid assessment types, an error like the following is thrown:
```
│ Error: Resource precondition failed
│ 
│   on assessment_validation.tf line 24, in resource "null_resource" "validate_assessment_type":
│   24:       condition     = contains(var.valid_assessment_types, var.assessment_type)
│     ├────────────────
│     │ var.assessment_type is "WiFi"
│     │ var.valid_assessment_types is list of string with 3 elements
│ 
│ Invalid assessment type provided: WiFi.  Valid types are: PenTest, Phishing, RedTeam
```
* When an assessment type is provided that is in the provided list of valid assessment types, no validation errors are thrown during a `terraform plan` or `terraform apply`.
* When an invalid regex is provided as the assessment ID regex, an error like the following is thrown:
```
│ Error: Invalid function argument
│ 
│   on assessment_validation.tf line 15, in resource "null_resource" "validate_assessment_id":
│   15:       condition     = length(regexall(var.valid_assessment_id_regex, var.assessment_id)) == 1
│     ├────────────────
│     │ var.valid_assessment_id_regex is "^ASMT\\"
│ 
│ Invalid value for "pattern" parameter: invalid regexp pattern: trailing backslash at end of expression in .
```
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.