### PR TITLE
Allow Windows instances to reach Teamserver instances on ports 5000-5999

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,7 @@ the COOL environment.
 | [aws_security_group_rule.teamserver_egress_to_kali_instances_via_5000_to_5999](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.teamserver_ingress_from_kali_instances_via_5000_to_5999](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.teamserver_ingress_from_kali_via_imaps_and_cs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.teamserver_ingress_from_windows_instances_via_5000_to_5999_tcp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.terraformer_egress_anywhere_via_http](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.terraformer_egress_anywhere_via_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.terraformer_egress_anywhere_via_ssh](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
@@ -382,6 +383,7 @@ the COOL environment.
 | [aws_security_group_rule.windows_egress_to_kali_instances](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.windows_egress_to_nessus_via_web_ui](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.windows_egress_to_pentestportal_via_web](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.windows_egress_to_teamserver_instances_via_5000_to_5999_tcp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.windows_ingress_from_kali_instances](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_subnet.operations](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_subnet.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |

--- a/teamserver_sg.tf
+++ b/teamserver_sg.tf
@@ -77,3 +77,17 @@ resource "aws_security_group_rule" "teamserver_ingress_from_kali_instances_via_5
   from_port                = 5000
   to_port                  = 5999
 }
+
+# Allow ingress to Teamserver instances from Windows instances on
+# ports 5000-5999 (TCP only).  This port range was requested for use
+# by assessment operators in cisagov/cool-system-internal#127.
+resource "aws_security_group_rule" "teamserver_ingress_from_windows_instances_via_5000_to_5999_tcp" {
+  provider = aws.provisionassessment
+
+  security_group_id        = aws_security_group.teamserver.id
+  type                     = "ingress"
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.windows.id
+  from_port                = 5000
+  to_port                  = 5999
+}

--- a/windows_sg.tf
+++ b/windows_sg.tf
@@ -74,3 +74,17 @@ resource "aws_security_group_rule" "windows_ingress_from_kali_instances" {
   from_port                = 0
   to_port                  = 65535
 }
+
+# Allow egress from Windows to Teamserver instances on ports 5000-5999
+# (TCP only).  This port range was requested for use by assessment
+# operators in cisagov/cool-system-internal#127.
+resource "aws_security_group_rule" "windows_egress_to_teamserver_instances_via_5000_to_5999_tcp" {
+  provider = aws.provisionassessment
+
+  security_group_id        = aws_security_group.windows.id
+  type                     = "egress"
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.teamserver.id
+  from_port                = 5000
+  to_port                  = 5999
+}

--- a/windows_sg.tf
+++ b/windows_sg.tf
@@ -75,9 +75,9 @@ resource "aws_security_group_rule" "windows_ingress_from_kali_instances" {
   to_port                  = 65535
 }
 
-# Allow egress from Windows to Teamserver instances on ports 5000-5999
-# (TCP only).  This port range was requested for use by assessment
-# operators in cisagov/cool-system-internal#127.
+# Allow egress from Windows instances to Teamserver instances on
+# ports 5000-5999 (TCP only).  This port range was requested for use
+# by assessment operators in cisagov/cool-system-internal#127.
 resource "aws_security_group_rule" "windows_egress_to_teamserver_instances_via_5000_to_5999_tcp" {
   provider = aws.provisionassessment
 


### PR DESCRIPTION
## 🗣 Description ##

This pull request puts some security group rules in place to allow Windows instances to reach Teamserver instances on ports 5000-5999.

## 💭 Motivation and context ##

Resolves cisagov/cool-system-internal#127.

## 🧪 Testing ##

All automated tests pass.  I also applied these changes to env6 in our staging COOL environment and then verified that I could:
1. Run `yes | nc -l 5100` on a Teamserver instance
1. Point a web browser on the Windows instance to `http://teamserver0.env6`
1. See the HTML request from the web browser appear in the `nc` session on the Teamserver instance
1. Run `nc teamserver0.env6 5100` in a terminal on a Windows instance
1. View the many lovely `y\n`s that appear in the `nc` session on the Windows instance

In this way I verified that:
- The Windows instances can reach the Teamserver instances on the 5000-5999 port range
- Any responses sent by the Teamserver instances via ephemeral ports indeed reach the Windows servers

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.