### PR TITLE
Add permissions boundary policy to Terraformer role

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ the COOL environment.
 | [aws_iam_role_policy_attachment.nessus_parameterstorereadonly_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.provisionassessment_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.provisionssmsessionmanager_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.read_only_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.ssm_agent_policy_attachment_assessorportal](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.ssm_agent_policy_attachment_debiandesktop](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.ssm_agent_policy_attachment_egressassess](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ the COOL environment.
 | [aws_iam_policy.nessus_parameterstorereadonly_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.provisionassessment_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.provisionssmsessionmanager_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.terraformer_permissions_boundary_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.terraformer_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.assessorportal_instance_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.debiandesktop_instance_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
@@ -202,7 +203,6 @@ the COOL environment.
 | [aws_iam_role_policy_attachment.nessus_parameterstorereadonly_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.provisionassessment_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.provisionssmsessionmanager_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.read_only_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.ssm_agent_policy_attachment_assessorportal](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.ssm_agent_policy_attachment_debiandesktop](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.ssm_agent_policy_attachment_egressassess](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
@@ -446,6 +446,7 @@ the COOL environment.
 | [aws_iam_policy_document.teamserver_assume_delegated_role_policy_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.terraformer_assume_delegated_role_policy_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.terraformer_assume_role_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.terraformer_permissions_boundary_policy_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.terraformer_policy_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.users_account_assume_role_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_organizations_organization.cool](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/organizations_organization) | data source |
@@ -521,6 +522,8 @@ the COOL environment.
 | ssm\_key\_samba\_username | The AWS SSM Parameter Store parameter that contains the username of the Samba user (e.g. "/samba/username"). | `string` | `"/samba/username"` | no |
 | ssm\_key\_vnc\_username | The AWS SSM Parameter Store parameter that contains the username of the VNC user (e.g. "/vnc/username"). | `string` | `"/vnc/username"` | no |
 | tags | Tags to apply to all AWS resources created | `map(string)` | `{}` | no |
+| terraformer\_permissions\_boundary\_policy\_description | The description to associate with the IAM permissions boundary policy attached to the Terraformer instance role in order to protect the foundational resources deployed in this account. | `string` | `"Defines the IAM permissions boundary for Terraformer instances in order to protect the foundational resources deployed in this account."` | no |
+| terraformer\_permissions\_boundary\_policy\_name | The name to assign the IAM permissions boundary policy attached to the Terraformer instance role in order to protect the foundational resources deployed in this account. | `string` | `"TerraformerPermissionsBoundary"` | no |
 | terraformer\_role\_description | The description to associate with the IAM role (and policy) that allows Terraformer instances to create appropriate AWS resources in this account. | `string` | `"Allows Terraformer instances to create appropriate AWS resources in this account."` | no |
 | terraformer\_role\_name | The name to assign the IAM role (and policy) that allows Terraformer instances to create appropriate AWS resources in this account. | `string` | `"Terraformer"` | no |
 | valid\_assessment\_id\_regex | A regular expression that specifies valid assessment identifiers (e.g. "^ASMT[[:digit:]]{4}$"). | `string` | `""` | no |

--- a/README.md
+++ b/README.md
@@ -589,6 +589,7 @@ the COOL environment.
 | sts\_endpoint\_client\_security\_group | A security group for any instances that wish to communicate with the STS VPC endpoint. |
 | teamserver\_instance\_profiles | The instance profiles for the Teamserver instances. |
 | teamserver\_instances | The Teamserver instances. |
+| terraformer\_permissions\_boundary\_policy | The permissions boundary policy for the Terraformer instances. |
 | teamserver\_security\_group | The security group for the Teamserver instances. |
 | terraformer\_instances | The Terraformer instances. |
 | terraformer\_security\_group | The security group for the Terraformer instances. |

--- a/outputs.tf
+++ b/outputs.tf
@@ -273,6 +273,11 @@ output "terraformer_instances" {
   description = "The Terraformer instances."
 }
 
+output "terraformer_permissions_boundary_policy" {
+  value       = aws_iam_policy.terraformer_permissions_boundary_policy
+  description = "The permissions boundary policy for the Terraformer instances."
+}
+
 output "terraformer_security_group" {
   value       = aws_security_group.terraformer
   description = "The security group for the Terraformer instances."

--- a/terraformer_permissionsboundary.tf
+++ b/terraformer_permissionsboundary.tf
@@ -33,8 +33,8 @@ data "aws_iam_policy_document" "terraformer_permissions_boundary_policy_doc" {
     sid = "AllowReadingEC2ResourcesTaggedByTeam"
   }
 
-  # Deny modification of any resources tagged by the team that deploys this
-  # root module, but allow anything else.
+  # Allow modification of any resources, except those tagged by the team that
+  # deploys this root module.
   statement {
     actions = [
       "*",

--- a/terraformer_permissionsboundary.tf
+++ b/terraformer_permissionsboundary.tf
@@ -3,6 +3,7 @@
 # * Deny modification of any resources tagged by the team that deploys this
 #   root module, with some exceptions (detailed below).
 # * Deny use of the Guacamole, Samba, and Terraformer instance roles.
+# * Deny modification of CloudFormation resources created by Control Tower.
 # * Deny modification or deletion of this permissions boundary policy.
 # * Deny removal of this permissions boundary policy from users and roles.
 # * Deny creation of users or roles that do not have this permissions boundary.
@@ -170,7 +171,7 @@ data "aws_iam_policy_document" "terraformer_permissions_boundary_policy_doc" {
   }
 
   # Don't allow Terraformer instances to touch the CloudFormation foo
-  # put in place by ControlTower.  This is not covered by the earlier
+  # put in place by Control Tower.  This is not covered by the earlier
   # statement allowing full access to resources that are not tagged as
   # belonging to the team that deploys this root module, since CloudFormation
   # resources do not accept tags.

--- a/terraformer_permissionsboundary.tf
+++ b/terraformer_permissionsboundary.tf
@@ -190,11 +190,11 @@ data "aws_iam_policy_document" "terraformer_permissions_boundary_policy_doc" {
     sid = "AllowModifyingS3Endpoint"
   }
 
-  # Don't allow Terraformer instances to touch the CloudFormation foo
-  # put in place by Control Tower.  This is not covered by the earlier
-  # statement allowing full access to resources that are not tagged as
-  # belonging to the team that deploys this root module, since CloudFormation
-  # resources do not accept tags.
+  # Don't allow Terraformer instances to touch the CloudFormation foo put in
+  # place by Control Tower.  CloudFormation resources do not accept tags and
+  # thus cannot be tagged with a team tag, which is why this statement is needed
+  # (an earlier statement prevents modification of any resources tagged by the
+  # team that deploys this root module).
   statement {
     actions = [
       "cloudformation:*",

--- a/terraformer_permissionsboundary.tf
+++ b/terraformer_permissionsboundary.tf
@@ -12,6 +12,27 @@
 data "aws_iam_policy_document" "terraformer_permissions_boundary_policy_doc" {
   provider = aws.provisionassessment
 
+  # Allow read-only access to EC2 resources tagged by the team that deploys
+  # this root module.
+  statement {
+    actions = [
+      "ec2:Describe*",
+      "ec2:Get*",
+      "ec2:List*",
+    ]
+    condition {
+      test = "StringEquals"
+      values = [
+        var.tags["Team"],
+      ]
+      variable = "aws:ResourceTag/Team"
+    }
+    resources = [
+      "*",
+    ]
+    sid = "AllowReadingEC2ResourcesTaggedByTeam"
+  }
+
   # Deny modification of any resources tagged by the team that deploys this
   # root module, but allow anything else.
   statement {
@@ -115,7 +136,6 @@ data "aws_iam_policy_document" "terraformer_permissions_boundary_policy_doc" {
       "ec2:CreateSecurityGroup",
       "ec2:CreateVpcPeeringConnection",
       "ec2:DeleteVpcPeeringConnection",
-      "ec2:DescribeVpcPeeringConnections",
     ]
     resources = [
       aws_vpc.assessment.arn,

--- a/terraformer_permissionsboundary.tf
+++ b/terraformer_permissionsboundary.tf
@@ -23,7 +23,7 @@ data "aws_iam_policy_document" "terraformer_permissions_boundary_policy_doc" {
     condition {
       test = "StringEquals"
       values = [
-        var.tags["Team"],
+        lookup(var.tags, "Team", "Undefined Team tag value"),
       ]
       variable = "aws:ResourceTag/Team"
     }
@@ -42,7 +42,7 @@ data "aws_iam_policy_document" "terraformer_permissions_boundary_policy_doc" {
     condition {
       test = "StringNotEquals"
       values = [
-        var.tags["Team"],
+        lookup(var.tags, "Team", "Undefined Team tag value"),
       ]
       variable = "aws:ResourceTag/Team"
     }

--- a/terraformer_permissionsboundary.tf
+++ b/terraformer_permissionsboundary.tf
@@ -79,8 +79,8 @@ data "aws_iam_policy_document" "terraformer_permissions_boundary_policy_doc" {
     sid = "AllowUsingCOOLAMIKMSKey"
   }
 
-  # Allow the launching of new instances in the operations subnet,
-  # using the existing security groups.
+  # Allow the launching of new instances in the operations subnet and the
+  # first private subnet, using the existing security groups.
   #
   # Also allow the ModifyNetworkInterfaceAttribute permission when our
   # existing security groups are involved.  This is necessary when the

--- a/terraformer_permissionsboundary.tf
+++ b/terraformer_permissionsboundary.tf
@@ -1,0 +1,270 @@
+# Create the IAM permissions boundary policy for the Terraformer EC2 instances.
+# This policy allows full AWS permissions except for the following:
+# * Deny modification of any resources tagged by the team that deploys this
+#   root module, with some exceptions (detailed below).
+# * Deny use of the Guacamole, Samba, and Terraformer instance roles.
+# * Deny modification or deletion of this permissions boundary policy.
+# * Deny removal of this permissions boundary policy from users and roles.
+# * Deny creation of users or roles that do not have this permissions boundary.
+# * Deny applying any other permission boundary policies to users or roles.
+
+data "aws_iam_policy_document" "terraformer_permissions_boundary_policy_doc" {
+  provider = aws.provisionassessment
+
+  # Deny modification of any resources tagged by the team that deploys this
+  # root module, but allow anything else.
+  statement {
+    actions = [
+      "*",
+    ]
+    condition {
+      test = "StringNotEquals"
+      values = [
+        var.tags["Team"],
+      ]
+      variable = "aws:ResourceTag/Team"
+    }
+    resources = [
+      "*",
+    ]
+    sid = "DenyModifyingResourcesTaggedByTeam"
+  }
+
+  # Deny use of the Guacamole, Samba, and Terraformer instance roles.
+  statement {
+    actions = [
+      "iam:PassRole",
+    ]
+    effect = "Deny"
+    resources = [
+      aws_iam_role.guacamole_instance_role.arn,
+      aws_iam_role.samba_instance_role.arn,
+      aws_iam_role.terraformer_instance_role.arn,
+    ]
+    sid = "DenyPassingProtectedInstanceRoles"
+  }
+
+  # Allow use of the KMS key used to encrypt COOL AMIs.  This explicit "allow"
+  # is necessary because the key is tagged with the "Team" tag.
+  statement {
+    actions = [
+      "kms:Decrypt",
+      "kms:ReEncryptFrom",
+    ]
+    resources = [
+      data.terraform_remote_state.images.outputs.ami_kms_key.arn
+    ]
+    sid = "AllowUsingCOOLAMIKMSKey"
+  }
+
+  # Allow the launching of new instances in the operations subnet,
+  # using the existing security groups.
+  #
+  # Also allow the ModifyNetworkInterfaceAttribute permission when our
+  # existing security groups are involved.  This is necessary when the
+  # Terraformer instance is used to add or remove security groups from
+  # an instance.
+  #
+  # This explicit "allow" is necessary because the resources below are tagged
+  # with the "Team" tag.
+  statement {
+    actions = [
+      "ec2:RunInstances",
+      "ec2:ModifyNetworkInterfaceAttribute",
+    ]
+    resources = [
+      # Subnets.  The ModifyNetworkInterfaceAttribute doesn't care
+      # about these resources, but they don't hurt anything being
+      # here.
+      aws_subnet.operations.arn,
+      # The private subnet where Guacamole and Terraformer instances
+      # currently live.
+      aws_subnet.private[var.private_subnet_cidr_blocks[0]].arn,
+      # Security groups
+      aws_security_group.assessorportal.arn,
+      aws_security_group.cloudwatch_agent_endpoint_client.arn,
+      aws_security_group.debiandesktop.arn,
+      aws_security_group.dynamodb_endpoint_client.arn,
+      aws_security_group.ec2_endpoint_client.arn,
+      aws_security_group.efs_client.arn,
+      aws_security_group.gophish.arn,
+      aws_security_group.guacamole_accessible.arn,
+      aws_security_group.kali.arn,
+      aws_security_group.nessus.arn,
+      aws_security_group.pentestportal.arn,
+      aws_security_group.s3_endpoint_client.arn,
+      aws_security_group.scanner.arn,
+      aws_security_group.smb_client.arn,
+      aws_security_group.ssm_agent_endpoint_client.arn,
+      aws_security_group.ssm_endpoint_client.arn,
+      aws_security_group.sts_endpoint_client.arn,
+      aws_security_group.teamserver.arn,
+      aws_security_group.windows.arn,
+    ]
+    sid = "AllowLaunchingOpsInstancesAndAddingRemovingSGsFromInstances"
+  }
+
+  # Allow Terraformer instances to create new security groups and routing tables
+  # and manage VPC peering connections in the assessment VPC.  This explicit
+  # "allow" is necessary because the VPC is tagged with the "Team" tag.
+  statement {
+    actions = [
+      "ec2:AcceptVpcPeeringConnection",
+      "ec2:CreateRouteTable",
+      "ec2:CreateSecurityGroup",
+      "ec2:CreateVpcPeeringConnection",
+      "ec2:DeleteVpcPeeringConnection",
+      "ec2:DescribeVpcPeeringConnections",
+    ]
+    resources = [
+      aws_vpc.assessment.arn,
+    ]
+    sid = "AllowCreatingSGsAndRoutingTablesInAssessmentVPC"
+  }
+
+  # Allow Terraformer instances to create, modify, and delete network
+  # ACLs for the operations subnet.  This explicit "allow" is necessary
+  # because the Operations NACL is tagged with the "Team" tag.
+  statement {
+    actions = [
+      "ec2:CreateNetworkAclEntry",
+      "ec2:DeleteNetworkAclEntry",
+      "ec2:ReplaceNetworkAclEntry",
+    ]
+    resources = [
+      aws_network_acl.operations.arn,
+    ]
+    sid = "AllowManagingOperationsNACL"
+  }
+
+  # Allow Terraformer instances to disassociate the default operations and
+  # private routing tables and associate additional routing tables with the
+  # first private subnet.  This is needed so that custom routing tables can
+  # be used.  This explicit "allow" is necessary because the resources below
+  # are tagged with the "Team" tag.
+  statement {
+    actions = [
+      "ec2:AssociateRouteTable",
+      "ec2:DisassociateRouteTable",
+    ]
+    resources = [
+      aws_default_route_table.operations.arn,
+      aws_route_table.private_route_table.arn,
+      aws_subnet.private[var.private_subnet_cidr_blocks[0]].arn,
+    ]
+    sid = "AllowAssociatingDisassociatingRouteTables"
+  }
+
+  # Allow Terraformer instances to modify the S3 VPC gateway endpoint.  This
+  # is needed so that the endpoint can be added to a new, custom route table.
+  # This explicit "allow" is necessary because the S3 endpoint is tagged with
+  # the "Team" tag.
+  statement {
+    actions = [
+      "ec2:ModifyVpcEndpoint",
+    ]
+    resources = [
+      aws_vpc_endpoint.s3.arn,
+    ]
+    sid = "AllowModifyingS3Endpoint"
+  }
+
+  # Don't allow Terraformer instances to touch the CloudFormation foo
+  # put in place by ControlTower.  This is not covered by the earlier
+  # statement allowing full access to resources that are not tagged as
+  # belonging to the team that deploys this root module, since CloudFormation
+  # resources do not accept tags.
+  statement {
+    actions = [
+      "cloudformation:*",
+    ]
+    effect = "Deny"
+    resources = [
+      "arn:aws:cloudformation:*:${local.assessment_account_id}:stack/StackSet-AWSControlTower*/*",
+    ]
+    sid = "DenyModifyingControlTowerStacks"
+  }
+
+  # Deny modification or deletion of this permissions boundary policy.
+  statement {
+    actions = [
+      "iam:CreatePolicyVersion",
+      "iam:DeletePolicy",
+      "iam:DeletePolicyVersion",
+      "iam:SetDefaultPolicyVersion",
+    ]
+    effect = "Deny"
+    resources = [
+      "arn:aws:iam::${local.assessment_account_id}:policy/${var.terraformer_permissions_boundary_policy_name}",
+    ]
+    sid = "DenyModifyingBoundaryPolicy"
+  }
+
+  # Deny deletion of permissions boundary from users or roles.
+  statement {
+    actions = [
+      "iam:DeleteRolePermissionsBoundary",
+      "iam:DeleteUserPermissionsBoundary",
+    ]
+    condition {
+      test = "StringEquals"
+      values = [
+        "arn:aws:iam::${local.assessment_account_id}:policy/${var.terraformer_permissions_boundary_policy_name}",
+      ]
+      variable = "iam:PermissionsBoundary"
+    }
+    effect = "Deny"
+    resources = [
+      "*",
+    ]
+    sid = "DenyRemovingBoundaryFromUsersAndRoles"
+  }
+
+  # Deny creation of users or roles that do not have this permissions boundary.
+  statement {
+    actions = [
+      "iam:CreateRole",
+      "iam:CreateUser",
+    ]
+    condition {
+      test = "StringNotEquals"
+      values = [
+        "arn:aws:iam::${local.assessment_account_id}:policy/${var.terraformer_permissions_boundary_policy_name}",
+      ]
+      variable = "iam:PermissionsBoundary"
+    }
+    effect = "Deny"
+    resources = [
+      "*",
+    ]
+    sid = "DenyCreatingUsersAndRolesWithoutBoundary"
+  }
+
+  # Deny applying any other permission boundary policies to users or roles.
+  statement {
+    actions = [
+      "iam:PutRolePermissionsBoundary",
+      "iam:PutUserPermissionsBoundary",
+    ]
+    condition {
+      test = "StringNotEquals"
+      values = [
+        "arn:aws:iam::${local.assessment_account_id}:policy/${var.terraformer_permissions_boundary_policy_name}",
+      ]
+      variable = "iam:PermissionsBoundary"
+    }
+    effect = "Deny"
+    resources = [
+      "*",
+    ]
+    sid = "DenyApplyingOtherBoundaryPolicies"
+  }
+}
+
+resource "aws_iam_policy" "terraformer_permissions_boundary_policy" {
+  provider = aws.provisionassessment
+
+  description = var.terraformer_permissions_boundary_policy_description
+  name        = var.terraformer_permissions_boundary_policy_name
+  policy      = data.aws_iam_policy_document.terraformer_permissions_boundary_policy_doc.json
+}

--- a/terraformer_policy.tf
+++ b/terraformer_policy.tf
@@ -40,8 +40,8 @@ data "aws_iam_policy_document" "terraformer_policy_doc" {
     ]
   }
 
-  # Allow the launching of new instances in the operations subnet,
-  # using the existing security groups.
+  # Allow the launching of new instances in the operations subnet and the
+  # first private subnet, using the existing security groups.
   #
   # Also allow the ModifyNetworkInterfaceAttribute permission when our
   # existing security groups are involved.  This is necessary when the

--- a/terraformer_policy.tf
+++ b/terraformer_policy.tf
@@ -10,8 +10,8 @@
 data "aws_iam_policy_document" "terraformer_policy_doc" {
   provider = aws.provisionassessment
 
-  # Deny modification of any resources tagged by the team that deploys this
-  # root module, but allow anything else.
+  # Allow modification of any resources, except those tagged by the team that
+  # deploys this root module.
   statement {
     actions = [
       "*",

--- a/terraformer_policy.tf
+++ b/terraformer_policy.tf
@@ -96,7 +96,6 @@ data "aws_iam_policy_document" "terraformer_policy_doc" {
       "ec2:CreateSecurityGroup",
       "ec2:CreateVpcPeeringConnection",
       "ec2:DeleteVpcPeeringConnection",
-      "ec2:DescribeVpcPeeringConnections",
     ]
     resources = [
       aws_vpc.assessment.arn,

--- a/terraformer_policy.tf
+++ b/terraformer_policy.tf
@@ -19,7 +19,7 @@ data "aws_iam_policy_document" "terraformer_policy_doc" {
     condition {
       test = "StringNotEquals"
       values = [
-        var.tags["Team"],
+        lookup(var.tags, "Team", "Undefined Team tag value"),
       ]
       variable = "aws:ResourceTag/Team"
     }

--- a/terraformer_policy.tf
+++ b/terraformer_policy.tf
@@ -28,7 +28,8 @@ data "aws_iam_policy_document" "terraformer_policy_doc" {
     ]
   }
 
-  # Allow use of the KMS key used to encrypt COOL AMIs.
+  # Allow use of the KMS key used to encrypt COOL AMIs.  This explicit "allow"
+  # is necessary because the key is tagged with the "Team" tag.
   statement {
     actions = [
       "kms:Decrypt",
@@ -46,6 +47,9 @@ data "aws_iam_policy_document" "terraformer_policy_doc" {
   # existing security groups are involved.  This is necessary when the
   # Terraformer instance is used to add or remove security groups from
   # an instance.
+  #
+  # This explicit "allow" is necessary because the resources below are tagged
+  # with the "Team" tag.
   statement {
     actions = [
       "ec2:RunInstances",
@@ -83,7 +87,8 @@ data "aws_iam_policy_document" "terraformer_policy_doc" {
   }
 
   # Allow Terraformer instances to create new security groups and routing tables
-  # and manage VPC peering connections in the assessment VPC.
+  # and manage VPC peering connections in the assessment VPC.  This explicit
+  # "allow" is necessary because the VPC is tagged with the "Team" tag.
   statement {
     actions = [
       "ec2:AcceptVpcPeeringConnection",
@@ -99,7 +104,8 @@ data "aws_iam_policy_document" "terraformer_policy_doc" {
   }
 
   # Allow Terraformer instances to create, modify, and delete network
-  # ACLs for the operations subnet.
+  # ACLs for the operations subnet.  This explicit "allow" is necessary
+  # because the Operations NACL is tagged with the "Team" tag.
   statement {
     actions = [
       "ec2:CreateNetworkAclEntry",
@@ -114,7 +120,8 @@ data "aws_iam_policy_document" "terraformer_policy_doc" {
   # Allow Terraformer instances to disassociate the default operations and
   # private routing tables and associate additional routing tables with the
   # first private subnet.  This is needed so that custom routing tables can
-  # be used.
+  # be used.  This explicit "allow" is necessary because the resources below
+  # are tagged with the "Team" tag.
   statement {
     actions = [
       "ec2:AssociateRouteTable",
@@ -129,6 +136,8 @@ data "aws_iam_policy_document" "terraformer_policy_doc" {
 
   # Allow Terraformer instances to modify the S3 VPC gateway endpoint.  This
   # is needed so that the endpoint can be added to a new, custom route table.
+  # This explicit "allow" is necessary because the S3 endpoint is tagged with
+  # the "Team" tag.
   statement {
     actions = [
       "ec2:ModifyVpcEndpoint",

--- a/terraformer_role.tf
+++ b/terraformer_role.tf
@@ -11,6 +11,16 @@ resource "aws_iam_role" "terraformer_role" {
   permissions_boundary = aws_iam_policy.terraformer_permissions_boundary_policy.arn
 }
 
+# Grant read-only access to everything.  This is specifically to allow
+# read access to existing resources that _are_ tagged as being created by
+# the team that deploys this root module.
+resource "aws_iam_role_policy_attachment" "read_only_policy_attachment" {
+  provider = aws.provisionassessment
+
+  policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+  role       = aws_iam_role.terraformer_role.name
+}
+
 # Allow full access to new resources and existing resources that _are
 # not_ tagged as being created by the team that deploys this root
 # module (with a few exceptions; see policy for details).

--- a/terraformer_role.tf
+++ b/terraformer_role.tf
@@ -5,22 +5,15 @@
 resource "aws_iam_role" "terraformer_role" {
   provider = aws.provisionassessment
 
-  assume_role_policy = data.aws_iam_policy_document.terraformer_assume_role_doc.json
-  description        = var.terraformer_role_description
-  name               = var.terraformer_role_name
-}
-
-# Grant read-only access to everything
-resource "aws_iam_role_policy_attachment" "read_only_policy_attachment" {
-  provider = aws.provisionassessment
-
-  policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
-  role       = aws_iam_role.terraformer_role.name
+  assume_role_policy   = data.aws_iam_policy_document.terraformer_assume_role_doc.json
+  description          = var.terraformer_role_description
+  name                 = var.terraformer_role_name
+  permissions_boundary = aws_iam_policy.terraformer_permissions_boundary_policy.arn
 }
 
 # Allow full access to new resources and existing resources that _are
 # not_ tagged as being created by the team that deploys this root
-# module.
+# module (with a few exceptions; see policy for details).
 resource "aws_iam_role_policy_attachment" "terraformer_policy_attachment" {
   provider = aws.provisionassessment
 

--- a/variables.tf
+++ b/variables.tf
@@ -330,6 +330,18 @@ variable "tags" {
   default     = {}
 }
 
+variable "terraformer_permissions_boundary_policy_description" {
+  type        = string
+  description = "The description to associate with the IAM permissions boundary policy attached to the Terraformer instance role in order to protect the foundational resources deployed in this account."
+  default     = "Defines the IAM permissions boundary for Terraformer instances in order to protect the foundational resources deployed in this account."
+}
+
+variable "terraformer_permissions_boundary_policy_name" {
+  type        = string
+  description = "The name to assign the IAM permissions boundary policy attached to the Terraformer instance role in order to protect the foundational resources deployed in this account."
+  default     = "TerraformerPermissionsBoundary"
+}
+
 variable "terraformer_role_description" {
   type        = string
   description = "The description to associate with the IAM role (and policy) that allows Terraformer instances to create appropriate AWS resources in this account."

--- a/variables.tf
+++ b/variables.tf
@@ -333,7 +333,7 @@ variable "tags" {
 variable "terraformer_permissions_boundary_policy_description" {
   type        = string
   description = "The description to associate with the IAM permissions boundary policy attached to the Terraformer instance role in order to protect the foundational resources deployed in this account."
-  default     = "Defines the IAM permissions boundary for Terraformer instances in order to protect the foundational resources deployed in this account."
+  default     = "The IAM permissions boundary policy attached to the Terraformer instance role in order to protect the foundational resources deployed in this account."
 }
 
 variable "terraformer_permissions_boundary_policy_name" {


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR creates a [permissions boundary policy](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html) and applies it to the Terraformer role.

The rules of the Terraformer boundary policy are:
* Not allowed to modify any resources tagged by the team that deploys the assessment environment (aside from a small number of exceptions that have been granted)
* Not allowed to assume the Guacamole, Samba, and Terraformer instance roles
* Not allowed to modify CloudFormation resources created by Control Tower
* Not allowed to modify or delete the permissions boundary policy
* Not allowed to remove the permissions boundary policy from users and roles that have it
* Not allowed to create users or roles that do not include the permissions boundary
* Not allowed to apply any other permission boundary policies to users or roles

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Previously, no IAM permissions were allowed by the Terraformer role because that would've allowed the creation of a policy with admin access.  This change allows the Terraformer role to perform IAM functions (e.g. creating custom roles and policies) as long as they don't break the rules specified in the permissions boundary policy.  This will make the Terraformer role more useful to our users and enable them to deploy a wider variety of resources in their environments.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I deployed these changes to a test environment and attempted to perform activities that should be prohibited by the boundary policy (e.g. modify resources that were tagged by deployment team, replace the boundary policy with a different one, remove the boundary policy from the Terraformer role).  In every case that I tested, I was unable to violate the rules of the boundary policy.

In addition, I confirmed (with help from others) that this boundary policy allows the following:
- [x] Successful deployment of [NuclearPond](https://github.com/DevSecOpsDocs/terraform-nuclear-pond) (with minor changes to the standard NuclearPond Terraform)
- [x] Successful deployment of all Terraform used by the Advanced Operations team

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
