### PR TITLE
Overwrite the `authorized_keys` file on Windows EC2 instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,6 +456,7 @@ the COOL environment.
 | [aws_ssm_parameter.artifact_export_region](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 | [aws_ssm_parameter.artifact_export_secret_access_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 | [aws_ssm_parameter.samba_username](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
+| [aws_ssm_parameter.vnc_public_ssh_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 | [aws_ssm_parameter.vnc_username](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 | [cloudinit_config.assessorworkbench_cloud_init_tasks](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs/data-sources/config) | data source |
 | [cloudinit_config.debiandesktop_cloud_init_tasks](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs/data-sources/config) | data source |
@@ -521,9 +522,10 @@ the COOL environment.
 | ssm\_key\_nessus\_admin\_password | The AWS SSM Parameter Store parameter that contains the password of the Nessus admin user (e.g. "/nessus/assessment/admin\_password"). | `string` | `"/nessus/assessment/admin_password"` | no |
 | ssm\_key\_nessus\_admin\_username | The AWS SSM Parameter Store parameter that contains the username of the Nessus admin user (e.g. "/nessus/assessment/admin\_username"). | `string` | `"/nessus/assessment/admin_username"` | no |
 | ssm\_key\_samba\_username | The AWS SSM Parameter Store parameter that contains the username of the Samba user (e.g. "/samba/username"). | `string` | `"/samba/username"` | no |
+| ssm\_key\_vnc\_ssh\_public\_key | The AWS SSM Parameter Store parameter that contains the SSH public key that corresponds to the private SSH key of the VNC user (e.g. "/vnc/ssh/ed25519\_public\_key"). | `string` | `"/vnc/ssh/ed25519_public_key"` | no |
 | ssm\_key\_vnc\_username | The AWS SSM Parameter Store parameter that contains the username of the VNC user (e.g. "/vnc/username"). | `string` | `"/vnc/username"` | no |
 | tags | Tags to apply to all AWS resources created | `map(string)` | `{}` | no |
-| terraformer\_permissions\_boundary\_policy\_description | The description to associate with the IAM permissions boundary policy attached to the Terraformer instance role in order to protect the foundational resources deployed in this account. | `string` | `"Defines the IAM permissions boundary for Terraformer instances in order to protect the foundational resources deployed in this account."` | no |
+| terraformer\_permissions\_boundary\_policy\_description | The description to associate with the IAM permissions boundary policy attached to the Terraformer instance role in order to protect the foundational resources deployed in this account. | `string` | `"The IAM permissions boundary policy attached to the Terraformer instance role in order to protect the foundational resources deployed in this account."` | no |
 | terraformer\_permissions\_boundary\_policy\_name | The name to assign the IAM permissions boundary policy attached to the Terraformer instance role in order to protect the foundational resources deployed in this account. | `string` | `"TerraformerPermissionsBoundary"` | no |
 | terraformer\_role\_description | The description to associate with the IAM role (and policy) that allows Terraformer instances to create appropriate AWS resources in this account. | `string` | `"Allows Terraformer instances to create appropriate AWS resources in this account."` | no |
 | terraformer\_role\_name | The name to assign the IAM role (and policy) that allows Terraformer instances to create appropriate AWS resources in this account. | `string` | `"Terraformer"` | no |
@@ -589,9 +591,9 @@ the COOL environment.
 | sts\_endpoint\_client\_security\_group | A security group for any instances that wish to communicate with the STS VPC endpoint. |
 | teamserver\_instance\_profiles | The instance profiles for the Teamserver instances. |
 | teamserver\_instances | The Teamserver instances. |
-| terraformer\_permissions\_boundary\_policy | The permissions boundary policy for the Terraformer instances. |
 | teamserver\_security\_group | The security group for the Teamserver instances. |
 | terraformer\_instances | The Terraformer instances. |
+| terraformer\_permissions\_boundary\_policy | The permissions boundary policy for the Terraformer instances. |
 | terraformer\_security\_group | The security group for the Terraformer instances. |
 | vpc | The VPC for this assessment environment. |
 | vpn\_server\_cidr\_block | The CIDR block for the COOL VPN. |

--- a/ec2launch/windows-setup.tpl.yml
+++ b/ec2launch/windows-setup.tpl.yml
@@ -2,7 +2,9 @@
 version: 1.0
 tasks:
   # Overwrite the authorized_keys file for the rvauser account to use the
-  # current public SSH key deployed to Linux-based instances.
+  # current public SSH key deployed to Linux-based instances. This should
+  # be removed once Windows AMIs are being built with the correct public
+  # SSH key(s) preloaded. Please see #218 for more information.
   - task: writeFile
     inputs:
       - frequency: once

--- a/ec2launch/windows-setup.tpl.yml
+++ b/ec2launch/windows-setup.tpl.yml
@@ -1,6 +1,14 @@
 ---
 version: 1.0
 tasks:
+  # Overwrite the authorized_keys file for the rvauser account to use the
+  # current public SSH key deployed to Linux-based instances.
+  - task: writeFile
+    inputs:
+      - frequency: once
+        destination: C:\Users\rvauser\.ssh\authorized_keys
+        content: |
+          ${vnc_public_ssh_key}
   # Extend the OS partition and set up the Samba share as a network drive
   - task: executeScript
     inputs:

--- a/locals.tf
+++ b/locals.tf
@@ -69,6 +69,8 @@ data "aws_ssm_parameter" "samba_username" {
   name = var.ssm_key_samba_username
 }
 
+# This should be removed once Windows AMIs are being built with the correct
+# public SSH key(s) preloaded. Please see #218 for more information.
 data "aws_ssm_parameter" "vnc_public_ssh_key" {
   provider = aws.parameterstorereadonly
 

--- a/locals.tf
+++ b/locals.tf
@@ -69,6 +69,12 @@ data "aws_ssm_parameter" "samba_username" {
   name = var.ssm_key_samba_username
 }
 
+data "aws_ssm_parameter" "vnc_public_ssh_key" {
+  provider = aws.parameterstorereadonly
+
+  name = var.ssm_key_vnc_ssh_public_key
+}
+
 data "aws_ssm_parameter" "vnc_username" {
   provider = aws.parameterstorereadonly
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -301,6 +301,11 @@ output "windows_instance_profile" {
 output "windows_instances" {
   value       = aws_instance.windows
   description = "The Windows instances."
+  # We are putting a decrypted SSM value in the Terraform state (see
+  # aws_ssm_parameter.vnc_public_ssh_key in locals.tf), so Terraform requires
+  # us to mark this output as sensitive.  However, since it's just the public
+  # SSH key used by Guacamole, we are fine with this.
+  sensitive = true
 }
 
 output "windows_security_group" {

--- a/variables.tf
+++ b/variables.tf
@@ -318,6 +318,12 @@ variable "ssm_key_samba_username" {
   default     = "/samba/username"
 }
 
+variable "ssm_key_vnc_ssh_public_key" {
+  type        = string
+  description = "The AWS SSM Parameter Store parameter that contains the SSH public key that corresponds to the private SSH key of the VNC user (e.g. \"/vnc/ssh/ed25519_public_key\")."
+  default     = "/vnc/ssh/ed25519_public_key"
+}
+
 variable "ssm_key_vnc_username" {
   type        = string
   description = "The AWS SSM Parameter Store parameter that contains the username of the VNC user (e.g. \"/vnc/username\")."

--- a/windows_ec2.tf
+++ b/windows_ec2.tf
@@ -61,6 +61,9 @@ resource "aws_instance" "windows" {
     {
       drive_letter       = "N",
       samba_server_input = join(",", aws_route53_record.samba_A[*].name),
+      # This should be removed once Windows AMIs are being built with the
+      # correct public SSH key(s) preloaded. Please see #218 for more
+      # information.
       vnc_public_ssh_key = data.aws_ssm_parameter.vnc_public_ssh_key.value,
     }
   )

--- a/windows_ec2.tf
+++ b/windows_ec2.tf
@@ -56,7 +56,14 @@ resource "aws_instance" "windows" {
     volume_type = "gp3"
     volume_size = 200
   }
-  user_data = templatefile("${path.module}/ec2launch/windows-setup.tpl.yml", { drive_letter = "N", samba_server_input = join(",", aws_route53_record.samba_A[*].name) })
+  user_data = templatefile(
+    "${path.module}/ec2launch/windows-setup.tpl.yml",
+    {
+      drive_letter       = "N",
+      samba_server_input = join(",", aws_route53_record.samba_A[*].name),
+      vnc_public_ssh_key = data.aws_ssm_parameter.vnc_public_ssh_key.value,
+    }
+  )
   vpc_security_group_ids = [
     aws_security_group.cloudwatch_agent_endpoint_client.id,
     aws_security_group.guacamole_accessible.id,


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request adjusts the [EC2Launch v2](https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/ec2launch-v2-overview.html) configuration to overwrite the `C:\Users\rvauser\.ssh\authorized_keys` file that defines the SSH keys allowed to connect to a running Windows EC2 instance.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The SSH public key that our current Windows AMIs are configured with is the old RSA key that was phased out with https://github.com/cisagov/guacamole-packer/pull/92 and https://github.com/cisagov/kali-packer/pull/147. This SSH key is used by Guacamole to connect to the Windows instances for file transfer and optionally by users of the Kali instances if they want to get command line access on a Windows instance. Now that fresh AMIs using the aforementioned PRs have been deployed it was reported that the Guacamole instance could no longer connect to Windows instances. Since our manual AMI building process is bother laborious and on-hold we are adding this band-aid to get a usable SSH public key onto Windows instances to maintain continuity of service.

@tauhid-smith-ctr I am pinging you for visibility on this issue.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
Automated tests pass. @dav3r first confirmed that Guacamole could not connect to a Windows instance in a staging environment and then re-deployed the Windows instance with this branch. Once re-deployed we confirmed that the `authorized_keys` file had changed and that the Guacamole instance could connect to the Windows instance as expected.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
