### PR TITLE
Add `iam:GetRole` to Terraformer permissions boundary policy

### DIFF
--- a/terraformer_permissionsboundary.tf
+++ b/terraformer_permissionsboundary.tf
@@ -33,6 +33,25 @@ data "aws_iam_policy_document" "terraformer_permissions_boundary_policy_doc" {
     sid = "AllowReadingEC2ResourcesTaggedByTeam"
   }
 
+  # Allow getting information about IAM roles tagged by the team that
+  # deploys this root module.
+  statement {
+    actions = [
+      "iam:GetRole",
+    ]
+    condition {
+      test = "StringEquals"
+      values = [
+        lookup(var.tags, "Team", "Undefined Team tag value"),
+      ]
+      variable = "aws:ResourceTag/Team"
+    }
+    resources = [
+      "*",
+    ]
+    sid = "AllowGettingInfoAboutRolesTaggedByTeam"
+  }
+
   # Allow modification of any resources, except those tagged by the team that
   # deploys this root module.
   statement {


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds [`iam:GetRole`](https://docs.aws.amazon.com/IAM/latest/APIReference/API_GetRole.html) to the Terraformer permissions boundary policy, specifically for roles tagged by the team that deploys this root module.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This additional functionality was requested by @Yablargo to support the [NuclearPond](https://github.com/DevSecOpsDocs/terraform-nuclear-pond) efforts enabled by #215.  Since `iam:GetRole` is a read-only operation, we are comfortable extending the permissions boundary in this case.

~⚠️ Note that automated tests will fail until https://github.com/cisagov/skeleton-tf-module/pull/186 is merged and its changes trickle down to this repository.~

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

To test this, I opened a session on a Terraformer instance in a Staging environment and assumed the `Terraformer` role.  Then, I attempted to get info about a different "protected" role (i.e. one that was tagged as being deployed by our team):
```
$ aws iam get-role --role-name debiandesktop_instance_role_envX-staging

An error occurred (AccessDenied) when calling the GetRole operation: User: arn:aws:sts::123456789012:assumed-role/Terraformer/testing is not authorized to perform: iam:GetRole on resource: role debiandesktop_instance_role_envX-staging because no permissions boundary allows the iam:GetRole action
```

As expected, I was denied.  Then, I applied the Terraform in this PR to my environment and when I re-ran the `aws iam get-role` command above, it returned the role information successfully.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.