### PR TITLE
Enable permissions to modify the default route table for operations s…

### DIFF
--- a/terraformer_permissionsboundary.tf
+++ b/terraformer_permissionsboundary.tf
@@ -177,11 +177,26 @@ data "aws_iam_policy_document" "terraformer_permissions_boundary_policy_doc" {
     sid = "AllowManagingOperationsNACL"
   }
 
+  # Allow Terraformer instances to modify the default routing table for the
+  # operations subnet.  This is needed so that additional routes can be added
+  # to peered VPCs.  This explicit "allow" is necessary because the resource
+  # below is tagged with the "Team" tag.
+  statement {
+    actions = [
+      "ec2:CreateRoute",
+      "ec2:DeleteRoute",
+      "ec2:ReplaceRoute",
+    ]
+    resources = [
+      aws_default_route_table.operations.arn,
+    ]
+  }
+
   # Allow Terraformer instances to disassociate the default operations and
   # private routing tables and associate additional routing tables with the
-  # first private subnet.  This is needed so that custom routing tables can
-  # be used.  This explicit "allow" is necessary because the resources below
-  # are tagged with the "Team" tag.
+  # operations and first private subnets.  This is needed so that custom routing
+  # tables can be used.  This explicit "allow" is necessary because the
+  # resources below are tagged with the "Team" tag.
   statement {
     actions = [
       "ec2:AssociateRouteTable",
@@ -191,6 +206,7 @@ data "aws_iam_policy_document" "terraformer_permissions_boundary_policy_doc" {
       aws_default_route_table.operations.arn,
       aws_route_table.private_route_table.arn,
       aws_subnet.private[var.private_subnet_cidr_blocks[0]].arn,
+      aws_subnet.operations.arn
     ]
     sid = "AllowAssociatingDisassociatingRouteTables"
   }

--- a/terraformer_permissionsboundary.tf
+++ b/terraformer_permissionsboundary.tf
@@ -205,8 +205,8 @@ data "aws_iam_policy_document" "terraformer_permissions_boundary_policy_doc" {
     resources = [
       aws_default_route_table.operations.arn,
       aws_route_table.private_route_table.arn,
+      aws_subnet.operations.arn,
       aws_subnet.private[var.private_subnet_cidr_blocks[0]].arn,
-      aws_subnet.operations.arn
     ]
     sid = "AllowAssociatingDisassociatingRouteTables"
   }

--- a/terraformer_policy.tf
+++ b/terraformer_policy.tf
@@ -144,8 +144,8 @@ data "aws_iam_policy_document" "terraformer_policy_doc" {
     resources = [
       aws_default_route_table.operations.arn,
       aws_route_table.private_route_table.arn,
+      aws_subnet.operations.arn,
       aws_subnet.private[var.private_subnet_cidr_blocks[0]].arn,
-      aws_subnet.operations.arn
     ]
   }
 

--- a/terraformer_policy.tf
+++ b/terraformer_policy.tf
@@ -116,11 +116,26 @@ data "aws_iam_policy_document" "terraformer_policy_doc" {
     ]
   }
 
+  # Allow Terraformer instances to modify the default routing table for the
+  # operations subnet.  This is needed so that additional routes can be added
+  # to peered VPCs.  This explicit "allow" is necessary because the resource
+  # below is tagged with the "Team" tag.
+  statement {
+    actions = [
+      "ec2:CreateRoute",
+      "ec2:DeleteRoute",
+      "ec2:ReplaceRoute",
+    ]
+    resources = [
+      aws_default_route_table.operations.arn,
+    ]
+  }
+
   # Allow Terraformer instances to disassociate the default operations and
   # private routing tables and associate additional routing tables with the
-  # first private subnet.  This is needed so that custom routing tables can
-  # be used.  This explicit "allow" is necessary because the resources below
-  # are tagged with the "Team" tag.
+  # operations and first private subnets.  This is needed so that custom routing
+  # tables can be used.  This explicit "allow" is necessary because the
+  # resources below are tagged with the "Team" tag.
   statement {
     actions = [
       "ec2:AssociateRouteTable",
@@ -130,6 +145,7 @@ data "aws_iam_policy_document" "terraformer_policy_doc" {
       aws_default_route_table.operations.arn,
       aws_route_table.private_route_table.arn,
       aws_subnet.private[var.private_subnet_cidr_blocks[0]].arn,
+      aws_subnet.operations.arn
     ]
   }
 


### PR DESCRIPTION
## 🗣 Description ##

VPC peering establishes a secure, private network connection by utilizing private IP addresses, connecting one or more Virtual Private Clouds (VPCs). To ensure the seamless peering of VPCs and the successful routing of data across the operations and private subnets, specific permissions need to be configured.

Here are the required permissions:

1. **Modify Default Operations Routing Table:** It's necessary to have the permission to make modifications to the default operations routing table. This adjustment involves adding routes for the newly peered networks. This step ensures that traffic can be correctly directed to the VPC networks that have been peered.
2. **Associate Operations Subnet with Operations Route Table:** It might seem logical that the default operations subnet should be automatically associated with the default operations route table; however, this was not the case.  In the context of VPC peering, this association is not automatically assumed either. Although AWS might consider this association as default behavior, it's insufficient for the requirements of VPC peering. Explicitly associating the operations subnet with a route table becomes vital in enabling routing to the peered networks.


## 💭 Context ##

I currently support the CISA VM RTA team and our infrastructure deployments within the COOL requires redirectors and other services in external Virtual Private Clouds (VPCs)  with various regions within AWS. Traffic between the operations subnet and our redirectors in external VPCs are visible to the internet over public IP space.  Our goal is to achieve internal routing of traffic between trusted infrastructure within AWS. This necessitates the implementation of VPC peering and ensuring that the appropriate permissions are in place for seamless and secure routing through the RTA environment.
