### PR TITLE
Increase the size of the Terraformer instance's root disk

### DIFF
--- a/terraformer_ec2.tf
+++ b/terraformer_ec2.tf
@@ -59,7 +59,7 @@ resource "aws_instance" "terraformer" {
     http_tokens = "required"
   }
   root_block_device {
-    volume_size = 20
+    volume_size = 128
     volume_type = "gp3"
   }
   user_data_base64 = data.cloudinit_config.terraformer_cloud_init_tasks[count.index].rendered


### PR DESCRIPTION
## 🗣 Description ##

This pull request increases the size of the Terraformer instance's root disk from 20GB to 128GB.

## 💭 Motivation and context ##

This change was requested by a nameless assessor.  See #228 for more details.

Resolves #228.

## 🧪 Testing ##

All automated tests pass.  I also deployed a Terraformer instance to our staging COOL environment with these changes and verified that it had a root disk of size 128GB.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.