### PR TITLE
Switch EFS to elastic throughput

### DIFF
--- a/efs.tf
+++ b/efs.tf
@@ -6,6 +6,7 @@ resource "aws_efs_file_system" "persistent_storage" {
   tags = {
     Name = "Persistent Storage"
   }
+  throughput_mode = "elastic"
 }
 
 # Mount targets for EFS

--- a/efs.tf
+++ b/efs.tf
@@ -22,8 +22,8 @@ resource "aws_efs_mount_target" "target" {
   for_each = toset([var.private_subnet_cidr_blocks[0]])
 
   file_system_id  = aws_efs_file_system.persistent_storage.id
-  subnet_id       = aws_subnet.private[each.value].id
   security_groups = [aws_security_group.efs_mount_target.id]
+  subnet_id       = aws_subnet.private[each.value].id
 }
 
 # EFS access points for EFS mount targets
@@ -73,12 +73,12 @@ resource "aws_security_group" "efs_mount_target" {
 resource "aws_security_group_rule" "allow_nfs_inbound" {
   provider = aws.provisionassessment
 
-  type                     = "ingress"
   from_port                = 2049
-  to_port                  = 2049
   protocol                 = "tcp"
   security_group_id        = aws_security_group.efs_mount_target.id
   source_security_group_id = aws_security_group.efs_client.id
+  to_port                  = 2049
+  type                     = "ingress"
 }
 
 # EFS client security group
@@ -93,10 +93,10 @@ resource "aws_security_group" "efs_client" {
 resource "aws_security_group_rule" "allow_nfs_outbound" {
   provider = aws.provisionassessment
 
-  type                     = "egress"
   from_port                = 2049
-  to_port                  = 2049
   protocol                 = "tcp"
   security_group_id        = aws_security_group.efs_client.id
   source_security_group_id = aws_security_group.efs_mount_target.id
+  to_port                  = 2049
+  type                     = "egress"
 }

--- a/provisionassessment_policy.tf
+++ b/provisionassessment_policy.tf
@@ -113,6 +113,7 @@ data "aws_iam_policy_document" "provisionassessment_policy_doc" {
       "elasticfilesystem:DescribeMountTargetSecurityGroups",
       "elasticfilesystem:TagResource",
       "elasticfilesystem:UntagResource",
+      "elasticfilesystem:UpdateFileSystem",
     ]
 
     resources = [


### PR DESCRIPTION
## 🗣 Description ##

This pull request switches the EFS from "bursting" to "elastic" throughput.

## 💭 Motivation and context ##

This should improve the performance of the EFS.  Resolves #230.

> [!TIP]
> This is a non-destructive Terraform change; it can be applied to an existing environment without loss of data.

## 🧪 Testing ##

All automated tests pass.  I applied this change to env1 in our staging COOL environment and verified that it functions as expected.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.