### PR TITLE
Allow bidirectional access between Windows and Teamserver via selected ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ the COOL environment.
 
 | Name | Version |
 |------|---------|
-| terraform | ~> 1.0 |
+| terraform | ~> 1.5 |
 | aws | ~> 4.9 |
 | cloudinit | ~> 2.0 |
 | null | ~> 3.0 |
@@ -375,6 +375,7 @@ the COOL environment.
 | [aws_security_group_rule.smb_server_ingress_from_smb_client](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.teamserver_egress_to_gophish_via_587](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.teamserver_egress_to_kali_instances_via_5000_to_5999](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.teamserver_egress_to_windows_instances_via_5000_to_5999_tcp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.teamserver_ingress_from_kali_instances_via_5000_to_5999](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.teamserver_ingress_from_kali_via_imaps_and_cs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.teamserver_ingress_from_windows_instances_via_5000_to_5999_tcp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
@@ -387,6 +388,7 @@ the COOL environment.
 | [aws_security_group_rule.windows_egress_to_pentestportal_via_web](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.windows_egress_to_teamserver_instances_via_5000_to_5999_tcp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.windows_ingress_from_kali_instances](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.windows_ingress_from_teamserver_instances_via_5000_to_5999_tcp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_subnet.operations](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_subnet.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_volume_attachment.assessorworkbench_docker](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/volume_attachment) | resource |

--- a/teamserver_sg.tf
+++ b/teamserver_sg.tf
@@ -78,9 +78,20 @@ resource "aws_security_group_rule" "teamserver_ingress_from_kali_instances_via_5
   to_port                  = 5999
 }
 
-# Allow ingress to Teamserver instances from Windows instances on
-# ports 5000-5999 (TCP only).  This port range was requested for use
-# by assessment operators in cisagov/cool-system-internal#127.
+# Allow access between Teamserver and Windows instances on ports
+# 5000-5999 (TCP only).  This port range was requested for use by
+# assessment operators in cisagov/cool-system-internal#127 and
+# cisagov/cool-assessment-terraform#235.
+resource "aws_security_group_rule" "teamserver_egress_to_windows_instances_via_5000_to_5999_tcp" {
+  provider = aws.provisionassessment
+
+  security_group_id        = aws_security_group.teamserver.id
+  type                     = "egress"
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.windows.id
+  from_port                = 5000
+  to_port                  = 5999
+}
 resource "aws_security_group_rule" "teamserver_ingress_from_windows_instances_via_5000_to_5999_tcp" {
   provider = aws.provisionassessment
 

--- a/windows_sg.tf
+++ b/windows_sg.tf
@@ -75,14 +75,25 @@ resource "aws_security_group_rule" "windows_ingress_from_kali_instances" {
   to_port                  = 65535
 }
 
-# Allow egress from Windows instances to Teamserver instances on
-# ports 5000-5999 (TCP only).  This port range was requested for use
-# by assessment operators in cisagov/cool-system-internal#127.
+# Allow access between Windows and Teamserver instances on ports
+# 5000-5999 (TCP only).  This port range was requested for use by
+# assessment operators in cisagov/cool-system-internal#127 and
+# cisagov/cool-assessment-terraform#235.
 resource "aws_security_group_rule" "windows_egress_to_teamserver_instances_via_5000_to_5999_tcp" {
   provider = aws.provisionassessment
 
   security_group_id        = aws_security_group.windows.id
   type                     = "egress"
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.teamserver.id
+  from_port                = 5000
+  to_port                  = 5999
+}
+resource "aws_security_group_rule" "windows_ingress_from_teamserver_instances_via_5000_to_5999_tcp" {
+  provider = aws.provisionassessment
+
+  security_group_id        = aws_security_group.windows.id
+  type                     = "ingress"
   protocol                 = "tcp"
   source_security_group_id = aws_security_group.teamserver.id
   from_port                = 5000


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the Terraform code to allow bidirectional access between Windows and Teamserver instances via ports 5000-5999.

## 💭 Motivation and context ##

Resolves #235.

## 🧪 Testing ##

All automated tests pass.  I also applied these changes to env51 in our production COOL environment, where @m1j09830 was able to confirm that they function as expected.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.