### PR TITLE
Move Debian Desktop, Samba, and Terraformer instances to Graviton

### DIFF
--- a/assessorworkbench_ec2.tf
+++ b/assessorworkbench_ec2.tf
@@ -2,6 +2,14 @@
 data "aws_ami" "assessorworkbench" {
   provider = aws.provisionassessment
 
+  most_recent = true
+  owners      = [local.images_account_id]
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
   filter {
     name = "name"
     values = [
@@ -10,17 +18,14 @@ data "aws_ami" "assessorworkbench" {
   }
 
   filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
-
-  filter {
     name   = "root-device-type"
     values = ["ebs"]
   }
 
-  most_recent = true
-  owners      = [local.images_account_id]
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
 }
 
 # The Assessor Workbench EC2 instances

--- a/debiandesktop_ec2.tf
+++ b/debiandesktop_ec2.tf
@@ -2,16 +2,19 @@
 data "aws_ami" "debiandesktop" {
   provider = aws.provisionassessment
 
+  most_recent = true
+  owners      = [local.images_account_id]
+
   filter {
-    name = "name"
-    values = [
-      "debian-hvm-*-x86_64-ebs"
-    ]
+    name   = "architecture"
+    values = ["arm64"]
   }
 
   filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
+    name = "name"
+    values = [
+      "debian-hvm-*-arm64-ebs"
+    ]
   }
 
   filter {
@@ -19,8 +22,10 @@ data "aws_ami" "debiandesktop" {
     values = ["ebs"]
   }
 
-  most_recent = true
-  owners      = [local.images_account_id]
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
 }
 
 # The "Debian desktop" EC2 instances

--- a/debiandesktop_ec2.tf
+++ b/debiandesktop_ec2.tf
@@ -43,7 +43,7 @@ resource "aws_instance" "debiandesktop" {
   ami                         = data.aws_ami.debiandesktop.id
   associate_public_ip_address = true
   iam_instance_profile        = aws_iam_instance_profile.debiandesktop.name
-  instance_type               = "t3.medium"
+  instance_type               = "t4g.medium"
   # AWS Instance Meta-Data Service (IMDS) options
   metadata_options {
     # Enable IMDS (this is the default value)

--- a/egressassess_ec2.tf
+++ b/egressassess_ec2.tf
@@ -2,6 +2,14 @@
 data "aws_ami" "egressassess" {
   provider = aws.provisionassessment
 
+  most_recent = true
+  owners      = [local.images_account_id]
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
   filter {
     name = "name"
     values = [
@@ -10,17 +18,14 @@ data "aws_ami" "egressassess" {
   }
 
   filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
-
-  filter {
     name   = "root-device-type"
     values = ["ebs"]
   }
 
-  most_recent = true
-  owners      = [local.images_account_id]
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
 }
 
 # The Egress-Assess EC2 instances

--- a/gophish_ec2.tf
+++ b/gophish_ec2.tf
@@ -2,6 +2,14 @@
 data "aws_ami" "gophish" {
   provider = aws.provisionassessment
 
+  most_recent = true
+  owners      = [local.images_account_id]
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
   filter {
     name = "name"
     values = [
@@ -10,17 +18,14 @@ data "aws_ami" "gophish" {
   }
 
   filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
-
-  filter {
     name   = "root-device-type"
     values = ["ebs"]
   }
 
-  most_recent = true
-  owners      = [local.images_account_id]
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
 }
 
 # The Gophish EC2 instances

--- a/guacamole_ec2.tf
+++ b/guacamole_ec2.tf
@@ -2,6 +2,14 @@
 data "aws_ami" "guacamole" {
   provider = aws.provisionassessment
 
+  most_recent = true
+  owners      = [local.images_account_id]
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
   filter {
     name = "name"
     values = [
@@ -10,17 +18,14 @@ data "aws_ami" "guacamole" {
   }
 
   filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
-
-  filter {
     name   = "root-device-type"
     values = ["ebs"]
   }
 
-  most_recent = true
-  owners      = [local.images_account_id]
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
 }
 
 # The Guacamole EC2 instance

--- a/kali_ec2.tf
+++ b/kali_ec2.tf
@@ -2,6 +2,14 @@
 data "aws_ami" "kali" {
   provider = aws.provisionassessment
 
+  most_recent = true
+  owners      = [local.images_account_id]
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
   filter {
     name = "name"
     values = [
@@ -10,17 +18,14 @@ data "aws_ami" "kali" {
   }
 
   filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
-
-  filter {
     name   = "root-device-type"
     values = ["ebs"]
   }
 
-  most_recent = true
-  owners      = [local.images_account_id]
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
 }
 
 # The Kali EC2 instances

--- a/nessus_ec2.tf
+++ b/nessus_ec2.tf
@@ -7,6 +7,14 @@
 data "aws_ami" "nessus" {
   provider = aws.provisionassessment
 
+  most_recent = true
+  owners      = [local.images_account_id]
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
   filter {
     name = "name"
     values = [
@@ -15,17 +23,14 @@ data "aws_ami" "nessus" {
   }
 
   filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
-
-  filter {
     name   = "root-device-type"
     values = ["ebs"]
   }
 
-  most_recent = true
-  owners      = [local.images_account_id]
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
 }
 
 # The Nessus EC2 instance

--- a/pentestportal_ec2.tf
+++ b/pentestportal_ec2.tf
@@ -2,6 +2,14 @@
 data "aws_ami" "docker" {
   provider = aws.provisionassessment
 
+  most_recent = true
+  owners      = [local.images_account_id]
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
   filter {
     name = "name"
     values = [
@@ -10,17 +18,14 @@ data "aws_ami" "docker" {
   }
 
   filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
-
-  filter {
     name   = "root-device-type"
     values = ["ebs"]
   }
 
-  most_recent = true
-  owners      = [local.images_account_id]
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
 }
 
 # The pentest portal EC2 instances

--- a/samba_ec2.tf
+++ b/samba_ec2.tf
@@ -42,7 +42,7 @@ resource "aws_instance" "samba" {
 
   ami                  = data.aws_ami.samba.id
   iam_instance_profile = aws_iam_instance_profile.samba.name
-  instance_type        = "t3.small"
+  instance_type        = "t4g.small"
   # AWS Instance Meta-Data Service (IMDS) options
   metadata_options {
     # Enable IMDS (this is the default value)

--- a/samba_ec2.tf
+++ b/samba_ec2.tf
@@ -2,16 +2,19 @@
 data "aws_ami" "samba" {
   provider = aws.provisionassessment
 
+  most_recent = true
+  owners      = [local.images_account_id]
+
   filter {
-    name = "name"
-    values = [
-      "samba-hvm-*-x86_64-ebs"
-    ]
+    name   = "architecture"
+    values = ["arm64"]
   }
 
   filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
+    name = "name"
+    values = [
+      "samba-hvm-*-arm64-ebs"
+    ]
   }
 
   filter {
@@ -19,8 +22,10 @@ data "aws_ami" "samba" {
     values = ["ebs"]
   }
 
-  most_recent = true
-  owners      = [local.images_account_id]
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
 }
 
 # The Samba EC2 instances

--- a/teamserver_ec2.tf
+++ b/teamserver_ec2.tf
@@ -2,6 +2,14 @@
 data "aws_ami" "teamserver" {
   provider = aws.provisionassessment
 
+  most_recent = true
+  owners      = [local.images_account_id]
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
   filter {
     name = "name"
     values = [
@@ -10,17 +18,14 @@ data "aws_ami" "teamserver" {
   }
 
   filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
-
-  filter {
     name   = "root-device-type"
     values = ["ebs"]
   }
 
-  most_recent = true
-  owners      = [local.images_account_id]
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
 }
 
 # The teamserver EC2 instances

--- a/terraformer_ec2.tf
+++ b/terraformer_ec2.tf
@@ -2,16 +2,19 @@
 data "aws_ami" "terraformer" {
   provider = aws.provisionassessment
 
+  most_recent = true
+  owners      = [local.images_account_id]
+
   filter {
-    name = "name"
-    values = [
-      "terraformer-hvm-*-x86_64-ebs"
-    ]
+    name   = "architecture"
+    values = ["arm64"]
   }
 
   filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
+    name = "name"
+    values = [
+      "terraformer-hvm-*-arm64-ebs"
+    ]
   }
 
   filter {
@@ -19,8 +22,10 @@ data "aws_ami" "terraformer" {
     values = ["ebs"]
   }
 
-  most_recent = true
-  owners      = [local.images_account_id]
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
 }
 
 # The Terraformer EC2 instances

--- a/terraformer_ec2.tf
+++ b/terraformer_ec2.tf
@@ -42,7 +42,7 @@ resource "aws_instance" "terraformer" {
 
   ami                  = data.aws_ami.terraformer.id
   iam_instance_profile = aws_iam_instance_profile.terraformer.name
-  instance_type        = "t3.xlarge"
+  instance_type        = "t4g.xlarge"
   # AWS Instance Meta-Data Service (IMDS) options
   metadata_options {
     # Enable IMDS (this is the default value)

--- a/windows_ec2.tf
+++ b/windows_ec2.tf
@@ -2,6 +2,14 @@
 data "aws_ami" "windows" {
   provider = aws.provisionassessment
 
+  most_recent = true
+  owners      = [local.images_account_id]
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
   filter {
     name = "name"
     values = [
@@ -10,17 +18,14 @@ data "aws_ami" "windows" {
   }
 
   filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
-
-  filter {
     name   = "root-device-type"
     values = ["ebs"]
   }
 
-  most_recent = true
-  owners      = [local.images_account_id]
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
 }
 
 # The Windows EC2 instances


### PR DESCRIPTION
## 🗣 Description ##

This pull request updates the Terraform code to deploy our Debian Desktop, Samba, and Terraformer instances to Graviton (ARM64) hardware.

See also:
- cisagov/debian-packer#64
- cisagov/samba-packer#49
- cisagov/terraformer-packer#55

## 💭 Motivation and context ##

ARM-based hardware should give us more performance for less money.  Such hardware also uses less energy, which is beneficial for the environment.

## 🧪 Testing ##

All automated tests pass.  I also deployed Graviton-based versions of these three instance types and verified that they function as expected.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.