### PR TITLE
Add `cloudwatch:TagResource` permission to ProvisionAssessment policy

### DIFF
--- a/provisionassessment_policy.tf
+++ b/provisionassessment_policy.tf
@@ -9,6 +9,7 @@ data "aws_iam_policy_document" "provisionassessment_policy_doc" {
       "cloudwatch:DeleteAlarms",
       "cloudwatch:ListTagsForResource",
       "cloudwatch:PutMetricAlarm",
+      "cloudwatch:TagResource",
     ]
 
     resources = [


### PR DESCRIPTION


# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds the `cloudwatch:TagResource` permission to the "ProvisionAssessment" policy.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Previously, this permission was not necessary, but it is now needed to successfully create CloudWatch alarms.

Without this change, we were seeing errors like this:

```
│ Error: creating CloudWatch Metric Alarm (ec2_cpu_utilization_i-1234567890abcdef): AccessDenied:
User: arn:aws:sts::123456789012:assumed-role/ProvisionAccount/admin is not authorized to perform:
cloudwatch:TagResource on resource:
arn:aws:cloudwatch:us-east-1:123456789012:alarm:ec2_cpu_utilization_i-1234567890abcdef
because no identity-based policy allows the cloudwatch:TagResource action
```

Thanks @adevine31 for bringing this to my attention! 👍 

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

@adevine31 confirmed that he was able to successfully apply the Terraform in this repository using the changes in this PR.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
