### PR TITLE
Run Nessus on Graviton instances

### DIFF
--- a/nessus_ec2.tf
+++ b/nessus_ec2.tf
@@ -12,13 +12,13 @@ data "aws_ami" "nessus" {
 
   filter {
     name   = "architecture"
-    values = ["x86_64"]
+    values = ["arm64"]
   }
 
   filter {
     name = "name"
     values = [
-      "nessus-hvm-*-x86_64-ebs"
+      "nessus-hvm-*-arm64-ebs"
     ]
   }
 
@@ -55,7 +55,7 @@ resource "aws_instance" "nessus" {
   ami                         = data.aws_ami.nessus.id
   associate_public_ip_address = true
   iam_instance_profile        = aws_iam_instance_profile.nessus.name
-  instance_type               = "m5.large"
+  instance_type               = "m7g.large"
   # AWS Instance Meta-Data Service (IMDS) options
   metadata_options {
     # Enable IMDS (this is the default value)


### PR DESCRIPTION
## 🗣 Description ##

Run Nessus on Graviton instances.

See also:
- cisagov/nessus-packer#81

## 💭 Motivation and context ##

Graviton instances are cheaper and more efficient, so they save money and are better for the environment.  Partially resolves cisagov/nessus-packer#79.

## 🧪 Testing ##

All automated tests pass.  I also deployed a Graviton-based Nessus instances to our staging COOL environment with these changes and verified that it functioned as expected.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.