### PR TITLE
Add a workspace-specific IAM role for writing to the Terraform state

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ the COOL environment.
 | email\_sending\_domain\_certreadrole | github.com/cisagov/cert-read-role-tf-module | n/a |
 | guacamole\_certreadrole | github.com/cisagov/cert-read-role-tf-module | n/a |
 | read\_terraform\_state | github.com/cisagov/terraform-state-read-role-tf-module | n/a |
-| read\_write\_terraform\_state | github.com/cisagov/terraform-state-read-role-tf-module | n/a |
+| read\_write\_terraform\_state | github.com/cisagov/terraform-state-read-role-tf-module | improvement%2Fadd-extra-read-only-states |
 | session\_manager | github.com/cisagov/session-manager-tf-module | n/a |
 | vpc\_flow\_logs | trussworks/vpc-flow-logs/aws | ~>2.0 |
 

--- a/README.md
+++ b/README.md
@@ -588,6 +588,7 @@ the COOL environment.
 | private\_subnet\_nat\_gateway | The NAT gateway for the private subnets. |
 | private\_subnets | The private subnets. |
 | read\_terraform\_state\_module | The IAM policies and role that allow read-only access to the cool-assessment-terraform workspace-specific state in the Terraform state bucket. |
+| read\_write\_terraform\_state\_module | The IAM policies and role that allow read-write access to the cool-assessment-terraform workspace-specific state in the Terraform state bucket. |
 | remote\_desktop\_url | The URL of the remote desktop gateway (Guacamole) for this assessment. |
 | s3\_endpoint\_client\_security\_group | A security group for any instances that wish to communicate with the S3 VPC endpoint. |
 | samba\_client\_security\_group | The security group that should be applied to all instance types that wish to mount the Samba file share being served by the Samba file share server instances. |

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ the COOL environment.
 | email\_sending\_domain\_certreadrole | github.com/cisagov/cert-read-role-tf-module | n/a |
 | guacamole\_certreadrole | github.com/cisagov/cert-read-role-tf-module | n/a |
 | read\_terraform\_state | github.com/cisagov/terraform-state-read-role-tf-module | n/a |
+| read\_write\_terraform\_state | github.com/cisagov/terraform-state-read-role-tf-module | feature%2Fadd-option-for-write-permission |
 | session\_manager | github.com/cisagov/session-manager-tf-module | n/a |
 | vpc\_flow\_logs | trussworks/vpc-flow-logs/aws | ~>2.0 |
 
@@ -522,6 +523,7 @@ the COOL environment.
 | provisionssmsessionmanager\_policy\_name | The name to assign the IAM policy that allows sufficient permissions to provision the SSM Document resource and set up SSM session logging in this assessment account. | `string` | `"ProvisionSSMSessionManager"` | no |
 | publish\_egress\_ip\_addresses | A boolean value that specifies whether EC2 instances in the operations subnet should be tagged to indicate that their public IP addresses may be published.  This is useful for deconfliction purposes.  Publishing these addresses can be done via the code in cisagov/publish-egress-ip-lambda and cisagov/publish-egress-ip-terraform. | `bool` | `false` | no |
 | read\_terraform\_state\_role\_name | The name to assign the IAM role (as well as the corresponding policy) that allows read-only access to the cool-assessment-terraform state in the S3 bucket where Terraform state is stored.  The %s in this name will be replaced by the value of the assessment\_account\_name variable. | `string` | `"ReadCoolAssessmentTerraformTerraformState-%s"` | no |
+| read\_write\_terraform\_state\_role\_name | The name to assign the IAM role (as well as the corresponding policy) that allows read-write access to the cool-assessment-terraform state in the S3 bucket where Terraform state is stored.  The %s in this name will be replaced by the value of the assessment\_account\_name variable. | `string` | `"ReadWriteCoolAssessmentTerraformTerraformState-%s"` | no |
 | session\_cloudwatch\_log\_group\_name | The name of the log group into which session logs are to be uploaded. | `string` | `"/ssm/session-logs"` | no |
 | ssm\_key\_artifact\_export\_access\_key\_id | The AWS SSM Parameter Store parameter that contains the AWS access key of the IAM user that can write to the assessment artifact export bucket (e.g. "/assessment\_artifact\_export/access\_key\_id"). | `string` | `"/assessment_artifact_export/access_key_id"` | no |
 | ssm\_key\_artifact\_export\_bucket\_name | The AWS SSM Parameter Store parameter that contains the name of the assessment artifact export bucket (e.g. "/assessment\_artifact\_export/bucket"). | `string` | `"/assessment_artifact_export/bucket"` | no |

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ the COOL environment.
 | email\_sending\_domain\_certreadrole | github.com/cisagov/cert-read-role-tf-module | n/a |
 | guacamole\_certreadrole | github.com/cisagov/cert-read-role-tf-module | n/a |
 | read\_terraform\_state | github.com/cisagov/terraform-state-read-role-tf-module | n/a |
-| read\_write\_terraform\_state | github.com/cisagov/terraform-state-read-role-tf-module | improvement%2Fadd-extra-read-only-states |
+| read\_write\_terraform\_state | github.com/cisagov/terraform-state-read-role-tf-module | n/a |
 | session\_manager | github.com/cisagov/session-manager-tf-module | n/a |
 | vpc\_flow\_logs | trussworks/vpc-flow-logs/aws | ~>2.0 |
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ the COOL environment.
 | email\_sending\_domain\_certreadrole | github.com/cisagov/cert-read-role-tf-module | n/a |
 | guacamole\_certreadrole | github.com/cisagov/cert-read-role-tf-module | n/a |
 | read\_terraform\_state | github.com/cisagov/terraform-state-read-role-tf-module | n/a |
-| read\_write\_terraform\_state | github.com/cisagov/terraform-state-read-role-tf-module | feature%2Fadd-option-for-write-permission |
+| read\_write\_terraform\_state | github.com/cisagov/terraform-state-read-role-tf-module | n/a |
 | session\_manager | github.com/cisagov/session-manager-tf-module | n/a |
 | vpc\_flow\_logs | trussworks/vpc-flow-logs/aws | ~>2.0 |
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -198,6 +198,11 @@ output "read_terraform_state_module" {
   value       = module.read_terraform_state
 }
 
+output "read_write_terraform_state_module" {
+  description = "The IAM policies and role that allow read-write access to the cool-assessment-terraform workspace-specific state in the Terraform state bucket."
+  value       = module.read_write_terraform_state
+}
+
 output "remote_desktop_url" {
   description = "The URL of the remote desktop gateway (Guacamole) for this assessment."
   value       = "https://${aws_route53_record.guacamole_A.name}"

--- a/read_write_terraform_state_role.tf
+++ b/read_write_terraform_state_role.tf
@@ -5,7 +5,7 @@
 # ------------------------------------------------------------------------------
 
 module "read_write_terraform_state" {
-  source = "github.com/cisagov/terraform-state-read-role-tf-module"
+  source = "github.com/cisagov/terraform-state-read-role-tf-module?ref=bugfix%2Fadd-permissions-to-write-dynamodb-lock-table"
 
   providers = {
     aws = aws.provisionterraform
@@ -19,9 +19,11 @@ module "read_write_terraform_state" {
 
   # The intent of this role is to allow selected IAM users to redeploy
   # this Terraform workspace.
-  account_ids        = [local.users_account_id]
-  create_assume_role = false
-  read_only          = false
+  account_ids         = [local.users_account_id]
+  create_assume_role  = false
+  lock_db_policy_name = format("TerraformLockDbPolicy-%s", replace(var.assessment_account_name, "/ \\((?P<env_type>[[:alnum:]]*)\\)$/", "-$env_type"))
+  lock_db_table_arn   = data.terraform_remote_state.terraform.outputs.state_lock_table.arn
+  read_only           = false
   # Note that the replace() function replaces "env0 (Staging)", for
   # example, with env0-Staging when it occurs at the end of the string
   role_name                   = format(var.read_write_terraform_state_role_name, replace(var.assessment_account_name, "/ \\((?P<env_type>[[:alnum:]]*)\\)$/", "-$env_type"))

--- a/read_write_terraform_state_role.tf
+++ b/read_write_terraform_state_role.tf
@@ -5,7 +5,7 @@
 # ------------------------------------------------------------------------------
 
 module "read_write_terraform_state" {
-  source = "github.com/cisagov/terraform-state-read-role-tf-module?ref=improvement%2Fadd-extra-read-only-states"
+  source = "github.com/cisagov/terraform-state-read-role-tf-module"
 
   providers = {
     aws = aws.provisionterraform

--- a/read_write_terraform_state_role.tf
+++ b/read_write_terraform_state_role.tf
@@ -1,0 +1,31 @@
+# ------------------------------------------------------------------------------
+# Create the IAM policy and role that allows read-write access to the
+# Terraform state for this project in the S3 bucket where Terraform
+# remote state is stored.
+# ------------------------------------------------------------------------------
+
+module "read_write_terraform_state" {
+  source = "github.com/cisagov/terraform-state-read-role-tf-module?ref=feature%2Fadd-option-for-write-permission"
+
+  providers = {
+    aws = aws.provisionterraform
+    # This provider is poorly named.  It is a provider that is allowed
+    # to create IAM resources in the account(s) listed in account_ids.
+    # In any event, this provider is not used here at all since the
+    # module is configured with create_assume_role equal to false.  We
+    # do have to put something there as a placeholder, though.
+    aws.users = aws.provisionassessment
+  }
+
+  # The intent of this role is to allow selected IAM users to redeploy
+  # this Terraform workspace.
+  account_ids        = [local.users_account_id]
+  create_assume_role = false
+  read_only          = false
+  # Note that the replace() function replaces "env0 (Staging)", for
+  # example, with env0-Staging when it occurs at the end of the string
+  role_name                   = format(var.read_write_terraform_state_role_name, replace(var.assessment_account_name, "/ \\((?P<env_type>[[:alnum:]]*)\\)$/", "-$env_type"))
+  terraform_state_bucket_name = "cisa-cool-terraform-state"
+  terraform_state_path        = "cool-assessment-terraform/terraform.tfstate"
+  terraform_workspace         = local.assessment_workspace_name
+}

--- a/read_write_terraform_state_role.tf
+++ b/read_write_terraform_state_role.tf
@@ -5,7 +5,7 @@
 # ------------------------------------------------------------------------------
 
 module "read_write_terraform_state" {
-  source = "github.com/cisagov/terraform-state-read-role-tf-module?ref=bugfix%2Fadd-permissions-to-write-dynamodb-lock-table"
+  source = "github.com/cisagov/terraform-state-read-role-tf-module"
 
   providers = {
     aws = aws.provisionterraform

--- a/read_write_terraform_state_role.tf
+++ b/read_write_terraform_state_role.tf
@@ -5,7 +5,7 @@
 # ------------------------------------------------------------------------------
 
 module "read_write_terraform_state" {
-  source = "github.com/cisagov/terraform-state-read-role-tf-module?ref=feature%2Fadd-option-for-write-permission"
+  source = "github.com/cisagov/terraform-state-read-role-tf-module"
 
   providers = {
     aws = aws.provisionterraform

--- a/taint_all_assessment_instances.sh
+++ b/taint_all_assessment_instances.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+# A script for tainting all assessment instance types in
+# cisagov/cool-assessment-terraform.  Note that this does not include
+# the Guacamole or Samba instances.
+#
+# Example:
+# $ AWS_PROFILE=cool-user AWS_SHARED_CREDENTIALS_FILE=~/.aws/production_credentials AWS_DEFAULT_REGION=us-east-1 ./taint_all_assessment_instances.sh
+
+# Export some environment variables that we want the terraform child
+# processes to inherit.
+export AWS_PROFILE
+export AWS_SHARED_CREDENTIALS_FILE
+export AWS_DEFAULT_REGION
+
+INSTANCES=$(terraform state list \
+  | sed --expression '/^aws_instance\.\(guacamole\|samba\)$/d' \
+    --expression '/^aws_instance\..*$/p' \
+    --quiet)
+
+for instance in $INSTANCES; do
+  terraform taint "$instance"
+done

--- a/variables.tf
+++ b/variables.tf
@@ -282,6 +282,12 @@ variable "read_terraform_state_role_name" {
   type        = string
 }
 
+variable "read_write_terraform_state_role_name" {
+  default     = "ReadWriteCoolAssessmentTerraformTerraformState-%s"
+  description = "The name to assign the IAM role (as well as the corresponding policy) that allows read-write access to the cool-assessment-terraform state in the S3 bucket where Terraform state is stored.  The %s in this name will be replaced by the value of the assessment_account_name variable."
+  type        = string
+}
+
 # This variable is copied over from cisagov/session-manager-tf-module
 # so that its value can be specified outside of that module.  This
 # allows us to impose a dependency of the module on the policy that


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds a workspace-specific IAM role that allows for writing the Terraform state.

## 💭 Motivation and context ##

Certain trusted users would like permission to redeploy their own COOL environments.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [x] Revert to the default branch of [cisagov/terraform-state-read-role-tf-module](https://github.com/cisagov/terraform-state-read-role-tf-module) once cisagov/terraform-state-read-role-tf-module#37 is merged.
- [x] Revert to the default branch of [cisagov/terraform-state-read-role-tf-module](https://github.com/cisagov/terraform-state-read-role-tf-module) once cisagov/terraform-state-read-role-tf-module#39 is merged.
- [x] Revert to the default branch of [cisagov/terraform-state-read-role-tf-module](https://github.com/cisagov/terraform-state-read-role-tf-module) once cisagov/terraform-state-read-role-tf-module#40 is merged.