### PR TITLE
Make the `sed` command work in MacOS

### DIFF
--- a/taint_all_assessment_instances.sh
+++ b/taint_all_assessment_instances.sh
@@ -17,10 +17,12 @@ export AWS_PROFILE
 export AWS_SHARED_CREDENTIALS_FILE
 export AWS_DEFAULT_REGION
 
+# I'm using short options here because MacOS's version of sed doesn't
+# support long options.  I'm also using the -E flag because MacOS's
+# version of sed does not use extended regexes by default.
 INSTANCES=$(terraform state list \
-  | sed --expression '/^aws_instance\.\(guacamole\|samba\)$/d' \
-    --expression '/^aws_instance\..*$/p' \
-    --quiet)
+  | sed -Ee '/^aws_instance\.(guacamole|samba\[[[:digit:]]+\])$/d' \
+    -Ee '/^aws_instance\..*$/p' -n)
 
 for instance in $INSTANCES; do
   terraform taint "$instance"


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the `sed` command in the script for tainting instances to work on both MacOS and Linux.  It also fixes a bug where the Samba instance was not being ignored as it should have been.

## 💭 Motivation and context ##

- MacOS's version of `sed` doesn't support long options, so we have to use short options in our script for tainting instances.
- MacOS's version of `sed` doesn't use extended regexes by default, so we have to add the `-E` flag.
- The Samba instances should not be tainted since the assessors do not have access to those instances.

## 🧪 Testing ##

All automated tests pass.  I tested this change locally and verified that it functioned on Linux, and @coffeegist did the same on MacOS.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.