### PR TITLE
Allow Kali instances to ssh to Nessus instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,7 @@ the COOL environment.
 | [aws_security_group_rule.ingress_from_sts_endpoint_client_to_sts_endpoint_via_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ingress_from_teamserver_to_gophish_via_ssh_and_smtp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.kali_egress_to_gophish_via_ssh](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.kali_egress_to_nessus_via_ssh](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.kali_egress_to_nessus_via_web_ui](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.kali_egress_to_pentestportal_via_ssh_and_web](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.kali_egress_to_teamserver_instances_via_5000_to_5999](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
@@ -370,6 +371,7 @@ the COOL environment.
 | [aws_security_group_rule.kali_ingress_from_windows_instances](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.kali_to_kali_via_ssh](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.nessus_ingress_from_debiandesktop_via_web_ui](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.nessus_ingress_from_kali_via_ssh](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.nessus_ingress_from_kali_via_web_ui](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.nessus_ingress_from_windows_via_web_ui](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.pentestportal_egress_to_anywhere_via_http_and_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |

--- a/kali_sg.tf
+++ b/kali_sg.tf
@@ -138,3 +138,16 @@ resource "aws_security_group_rule" "kali_egress_to_gophish_via_ssh" {
   to_port                  = 22
   type                     = "egress"
 }
+
+# Allow egress to Nessus instances via port 22 (SSH) for Ansible
+# configuration.  Requested in cool-system-internal#37.
+resource "aws_security_group_rule" "kali_egress_to_nessus_via_ssh" {
+  provider = aws.provisionassessment
+
+  from_port                = 22
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.kali.id
+  source_security_group_id = aws_security_group.nessus.id
+  to_port                  = 22
+  type                     = "egress"
+}

--- a/nessus_sg.tf
+++ b/nessus_sg.tf
@@ -50,6 +50,19 @@ resource "aws_security_group_rule" "nessus_ingress_from_windows_via_web_ui" {
   type                     = "ingress"
 }
 
+# Allow ingress from Kali instances via port 22 (SSH) for Ansible
+# configuration.  Requested in cool-system-internal#37.
+resource "aws_security_group_rule" "nessus_ingress_from_kali_via_ssh" {
+  provider = aws.provisionassessment
+
+  from_port                = 22
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.nessus.id
+  source_security_group_id = aws_security_group.kali.id
+  to_port                  = 22
+  type                     = "ingress"
+}
+
 # Allow ingress from anywhere via the allowed ports
 resource "aws_security_group_rule" "ingress_from_anywhere_to_nessus_via_allowed_ports" {
   provider = aws.provisionassessment


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds two security group rules to allow Kali instances to `ssh` to Nessus instances.

See also cisagov/nessus-packer#84.

## 💭 Motivation and context ##

Resolves cisagov/cool-system-internal#37.  (See in particular [this comment](https://github.com/cisagov/cool-system-internal/issues/37#issuecomment-2433076345) and the ones that follow.)

## 🧪 Testing ##

Automated tests pass.  I also tested these changes in our COOL staging environment (along with the changes from cisagov/nessus-packer#84) and found that they functioned as expected.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.